### PR TITLE
Fixes DeleteDirectory infinite recursion calls

### DIFF
--- a/FluentFTP/FtpClient.cs
+++ b/FluentFTP/FtpClient.cs
@@ -2572,6 +2572,13 @@ namespace FluentFTP {
             {
                 if (force) {
                     foreach (FtpListItem item in GetListing(path, options)) {
+
+                        // This check prevents infinity recursion, 
+                        // when FtpListItem is actual parent or current directory.
+                        // This could happen only when MLSD command is used for GetListing method.
+                        if (!item.FullName.ToLower().Contains(path.ToLower()) || string.Equals(item.FullName.ToLower(), path.ToLower()))
+                            continue;
+
                         switch (item.Type) {
                             case FtpFileSystemObjectType.File:
                                 DeleteFile(item.FullName);


### PR DESCRIPTION
Infinite recursion calls happens, when FtpListItem is referencing to parent or current directory and when `MLSD` command is used for `GetListing` method.