### PR TITLE
New - Support proxy HTTP 1.1/ User@Host

### DIFF
--- a/FluentFTP.Tests/Program.cs
+++ b/FluentFTP.Tests/Program.cs
@@ -25,7 +25,7 @@ namespace Tests {
             FtpTrace.AddListener(new ConsoleTraceListener());
 
             try {
-				/*foreach (int i in new int[] {
+                /*foreach (int i in new int[] {
                      (int)FtpDataConnectionType.EPSV,
                      (int)FtpDataConnectionType.EPRT,
                      (int)FtpDataConnectionType.PASV,
@@ -47,9 +47,9 @@ namespace Tests {
 
                 //StreamResponses();
 
-				//TestServer();
+                //TestServer();
 
-				//TestManualEncoding();
+                //TestManualEncoding();
 
                 //TestServer();
 
@@ -84,6 +84,8 @@ namespace Tests {
                 //TestUnixListing();
 
                 TestListPath();
+
+                TestListPathWithHttp11Proxy();
             }
             catch (Exception ex) {
                 Console.WriteLine(ex.ToString());
@@ -91,6 +93,24 @@ namespace Tests {
 
             Console.WriteLine("--DONE--");
             Console.ReadKey();
+        }
+
+        static void TestListPathWithHttp11Proxy()
+        {
+            using (FtpClient cl = new FtpClientHttp11Proxy(new Proxy { Host = "127.0.0.1", Port = 3128, })) // Credential = new NetworkCredential() 
+            {
+                cl.Credentials = new NetworkCredential(m_user, m_pass);
+                cl.Host = m_host;
+                cl.ValidateCertificate += OnValidateCertificate;
+                cl.DataConnectionType = FtpDataConnectionType.PASV;
+                cl.Connect();
+
+                foreach (FtpListItem item in cl.GetListing(null, FtpListOption.SizeModify | FtpListOption.ForceNameList))
+                {
+                    Console.WriteLine(item.Modified.Kind);
+                    Console.WriteLine(item.Modified);
+                }
+            }
         }
 
         static void TestListPath() {
@@ -112,8 +132,8 @@ namespace Tests {
                 cl.Host = m_host;
                 cl.EncryptionMode = FtpEncryptionMode.None;
                 cl.ValidateCertificate += new FtpSslValidation(delegate(FtpClient control, FtpSslValidationEventArgs e) {
-                        e.Accept = true;
-                    });
+                    e.Accept = true;
+                });
 
                 using (FtpDataStream s = (FtpDataStream)cl.OpenWrite("test.txt")) {
                     FtpReply r = s.CommandStatus;
@@ -180,24 +200,24 @@ namespace Tests {
 
 		static void TestManualEncoding() {
 			using (FtpClient cl = new FtpClient()) {
-				cl.Host = "ftptest";
-				cl.Credentials = new NetworkCredential("ftptest", "ftptest");
-				cl.Encoding = Encoding.Default;
+                cl.Host = "ftptest";
+                cl.Credentials = new NetworkCredential("ftptest", "ftptest");
+                cl.Encoding = Encoding.Default;
 
                 using (Stream s = cl.OpenWrite("test.txt")) {
                     s.Close();
                 }
-			}
-		}
+            }
+        }
 
         static void TestServer() {
             using (FtpClient cl = new FtpClient()) {
-				cl.Host = "ftptest";
+                cl.Host = "ftptest";
                 cl.Credentials = new NetworkCredential("ftptest", "ftptest");
-				cl.EncryptionMode = FtpEncryptionMode.Explicit;
+                cl.EncryptionMode = FtpEncryptionMode.Explicit;
 				cl.ValidateCertificate += (control, e) => {
-					e.Accept = true;
-				};
+                    e.Accept = true;
+                };
 
                 foreach (FtpListItem i in cl.GetListing("/")) {
                     Console.WriteLine(i.FullName);

--- a/FluentFTP.Tests/Program.cs
+++ b/FluentFTP.Tests/Program.cs
@@ -99,6 +99,8 @@ namespace Tests {
         {
             using (FtpClient cl = new FtpClientHttp11Proxy(new Proxy { Host = "127.0.0.1", Port = 3128, })) // Credential = new NetworkCredential() 
             {
+                Console.WriteLine($"FTPClient::ConnectionType = '{cl.ConnectionType}'");
+
                 cl.Credentials = new NetworkCredential(m_user, m_pass);
                 cl.Host = m_host;
                 cl.ValidateCertificate += OnValidateCertificate;

--- a/FluentFTP/FluentFTP.csproj
+++ b/FluentFTP/FluentFTP.csproj
@@ -41,6 +41,10 @@
     <Compile Include="Extensions\GetChecksum.cs" />
     <Compile Include="Extensions\MD5.cs" />
     <Compile Include="FtpClient.cs" />
+    <Compile Include="FtpClientHttp11Proxy.cs" />
+    <Compile Include="FtpClientProxy.cs" />
+    <Compile Include="FtpClientUserAtHostProxy.cs" />
+    <Compile Include="Proxy.cs" />
     <Compile Include="FtpDataStream.cs" />
     <Compile Include="FtpEnums.cs" />
     <Compile Include="FtpExceptions.cs" />

--- a/FluentFTP/FtpClient.cs
+++ b/FluentFTP/FtpClient.cs
@@ -563,6 +563,14 @@ namespace FluentFTP {
             }
         }
 
+        private string m_connectionType = "Default";
+        /// <summary> Gets the connection type </summary>
+        public string ConnectionType
+        {
+            get { return m_connectionType; }
+            protected set { m_connectionType = value; }
+        }
+
         /// <summary>
         /// Performs a bitwise and to check if the specified
         /// flag is set on the Capabilities enum property.

--- a/FluentFTP/FtpClientHttp11Proxy.cs
+++ b/FluentFTP/FtpClientHttp11Proxy.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+
+namespace FluentFTP
+{
+    /// <summary> A FTP client with a HTTP 1.1 proxy implementation. </summary>
+    public class FtpClientHttp11Proxy : FtpClientProxy
+    {
+        /// <summary> A FTP client with a HTTP 1.1 proxy implementation </summary>
+        /// <param name="proxy">Proxy informations</param>
+        public FtpClientHttp11Proxy(Proxy proxy) : base(proxy)
+        {
+        }
+
+        /// <summary> Redefine the first dialog: HTTP Trame for the HTTP 1.1 Proxy </summary>
+        protected override void Handshake()
+        {
+            var writer = new StreamWriter(BaseStream);
+            writer.Write("CONNECT {0}:{1} HTTP/1.1", Host, Port);
+            writer.Write("Host: {0}:{1}", Host, Port);
+            if (Proxy.Credential != null)
+            {
+                var credentialsHash = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(string.Format("{0}:{1}", Proxy.Credential.UserName, Proxy.Credential.Password)));
+                writer.WriteLine("Proxy-Authorization: Basic {0}", credentialsHash);
+            }
+            writer.WriteLine("User-Agent: custom-ftp-client");
+            writer.WriteLine();
+            writer.Flush();
+
+            var proxyConnectionReply = GetReply();
+            if (!proxyConnectionReply.Success)
+                throw new FtpException($"Can't connect {Host} via proxy {Proxy.Host}. Message : {proxyConnectionReply}");
+        }
+    }
+}

--- a/FluentFTP/FtpClientHttp11Proxy.cs
+++ b/FluentFTP/FtpClientHttp11Proxy.cs
@@ -10,6 +10,7 @@ namespace FluentFTP
         /// <param name="proxy">Proxy informations</param>
         public FtpClientHttp11Proxy(Proxy proxy) : base(proxy)
         {
+            ConnectionType = "HTTP 1.1 Proxy";
         }
 
         /// <summary> Redefine the first dialog: HTTP Trame for the HTTP 1.1 Proxy </summary>

--- a/FluentFTP/FtpClientProxy.cs
+++ b/FluentFTP/FtpClientProxy.cs
@@ -1,0 +1,25 @@
+namespace FluentFTP
+{
+    /// <summary>
+    /// Abstraction of an FtpClient with a proxy
+    /// </summary>
+    public abstract class FtpClientProxy : FtpClient
+    {
+        /// <summary> The proxy informations </summary>
+        protected Proxy Proxy { get; }
+
+        /// <summary> A FTP client with a HTTP 1.1 proxy implementation </summary>
+        /// <param name="proxy">Proxy informations</param>
+        protected FtpClientProxy(Proxy proxy)
+        {
+            Proxy = proxy;
+        }
+
+        /// <summary> Redefine connect for FtpClient : authentication on the Proxy  </summary>
+        /// <param name="stream">The socket stream.</param>
+        protected override void Connect(FtpSocketStream stream)
+        {
+            stream.Connect(Proxy.Host, Proxy.Port, InternetProtocolVersions);
+        }
+    }
+}

--- a/FluentFTP/FtpClientUserAtHostProxy.cs
+++ b/FluentFTP/FtpClientUserAtHostProxy.cs
@@ -1,0 +1,24 @@
+namespace FluentFTP
+{
+    /// <summary> A FTP client with a user@host proxy identification. </summary>
+    public class FtpClientUserAtHostProxy : FtpClientProxy
+    {
+        /// <summary> A FTP client with a user@host proxy identification. </summary>
+        /// <param name="proxy">Proxy informations</param>
+        public FtpClientUserAtHostProxy(Proxy proxy) 
+            : base(proxy)
+        {
+        }
+
+        /// <summary> Redefine the first dialog: auth with proxy information </summary>
+        protected override void Handshake()
+        {
+            // Proxy authentication eventually needed.
+            if (Proxy.Credential != null)
+                Authenticate(Proxy.Credential.UserName, Proxy.Credential.Password);
+
+            // Connection USER@Host meens to change user name to add host.
+            Credentials.UserName = $"{Credentials.UserName}@{Host}";
+        }
+    }
+}

--- a/FluentFTP/FtpClientUserAtHostProxy.cs
+++ b/FluentFTP/FtpClientUserAtHostProxy.cs
@@ -8,6 +8,7 @@ namespace FluentFTP
         public FtpClientUserAtHostProxy(Proxy proxy) 
             : base(proxy)
         {
+            ConnectionType = "User@Host";
         }
 
         /// <summary> Redefine the first dialog: auth with proxy information </summary>

--- a/FluentFTP/Proxy.cs
+++ b/FluentFTP/Proxy.cs
@@ -1,0 +1,17 @@
+using System.Net;
+
+namespace FluentFTP
+{
+    /// <summary> POCO holding proxy informations </summary>
+    public class Proxy
+    {
+        /// <summary> Proxy host name </summary>
+        public string Host { get; set; }
+
+        /// <summary> Proxy port </summary>
+        public int Port { get; set; }
+
+        /// <summary> Proxy credentials infomrations </summary>
+        public NetworkCredential Credential { get; set; }
+    }
+}


### PR DESCRIPTION
For #7 
HTTP1.1 proxy with or without authentication,
User@Host, with or without authentication.

Futur proxy implementation will benefit from FtpClientProxy abstract class.

Usage : 
using (FtpClient cl = new FtpClientHttp11Proxy(new Proxy { Host = "127.0.0.1", Port = 3128, }))
...