### PR TITLE
LocalEndpoint can be null

### DIFF
--- a/FluentFTP/FtpClient.cs
+++ b/FluentFTP/FtpClient.cs
@@ -1138,7 +1138,7 @@ namespace FluentFTP {
                 port = int.Parse(m.Groups["port"].Value);
             }
             else {
-                if (m_stream.LocalEndPoint.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
+				if (m_stream.LocalEndPoint!=null && m_stream.LocalEndPoint.AddressFamily != System.Net.Sockets.AddressFamily.InterNetwork)
                     throw new FtpException("Only IPv4 is supported by the PASV command. Use EPSV instead.");
 
                 if (!(reply = Execute("PASV")).Success)
@@ -1313,7 +1313,7 @@ namespace FluentFTP {
                 // The PORT and PASV commands do not work with IPv6 so
                 // if either one of those types are set change them
                 // to EPSV or EPRT appropriately.
-                if (m_stream.LocalEndPoint.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6) {
+				if (m_stream.LocalEndPoint!=null && m_stream.LocalEndPoint.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6) {
                     switch (type) {
                         case FtpDataConnectionType.PORT:
                             type = FtpDataConnectionType.EPRT;


### PR DESCRIPTION
I noticed that on Windows-Vista machine (Running on Mono Runtime) m_stream.LocalEndPoint migtht be null.

With the 2 changes the exceptions were eliminated. I did not see the reason for missing local endpoint data and there are much more references to be fixed. Perhaps it might be wise to create an dummy item to prevent Exceptions.