### PR TITLE
Added Serializable attribute to defined Exceptions

### DIFF
--- a/FluentFTP/FtpExceptions.cs
+++ b/FluentFTP/FtpExceptions.cs
@@ -4,6 +4,7 @@ namespace FluentFTP {
     /// <summary>
     /// FTP related error
     /// </summary>
+    [Serializable]
     public class FtpException : Exception {
         /// <summary>
         /// Initializes the exception object
@@ -15,6 +16,7 @@ namespace FluentFTP {
     /// <summary>
     /// Exception triggered on command failures
     /// </summary>
+    [Serializable]
     public class FtpCommandException : FtpException {
         string _code = null;
         /// <summary>
@@ -68,6 +70,7 @@ namespace FluentFTP {
     /// <summary>
     /// Exception is thrown when encryption could not be negotiated by the server
     /// </summary>
+    [Serializable]
     public class FtpSecurityNotAvailableException : FtpException {
         /// <summary>
         /// Default constructor


### PR DESCRIPTION
All custom exceptions has to have [Serializable] attribute to make sure they can be serialized when go thru WCF communication for example, or if roaming between AppDomain's.