### PR TITLE
Check dirPath is not empty string

### DIFF
--- a/FluentFTP/FtpClient.cs
+++ b/FluentFTP/FtpClient.cs
@@ -3310,7 +3310,7 @@ namespace FluentFTP {
 			try {
 				// create the folders
 				string dirPath = Path.GetDirectoryName(localPath);
-				if (!Directory.Exists(dirPath)) {
+				if (!String.IsNullOrWhiteSpace(dirPath) && !Directory.Exists(dirPath)) {
 					Directory.CreateDirectory(dirPath);
 				}
 			} catch (Exception ex1) {
@@ -3403,7 +3403,7 @@ namespace FluentFTP {
 			try {
 				// create the folders
 				string dirPath = Path.GetDirectoryName(localPath);
-				if (!Directory.Exists(dirPath)) {
+				if (!String.IsNullOrWhiteSpace(dirPath) && !Directory.Exists(dirPath)) {
 					Directory.CreateDirectory(dirPath);
 				}
 			} catch (Exception ex1) {


### PR DESCRIPTION
If `localPath` is just a filename, say 'file.txt', then the directory part returned by `Path.GetDirectoryName(localPath)` will be the empty string. Passing that to `Directory.Exists(dirPath)` will cause an exception.

This change ensures that we never pass the empty string to `Directory.Exists(dirPath)`. We can safely make this change, because if `dirPath` is the empty string, then we are downloading to the current directory, which definitely exists, so there is no need to create a new directory.

This fixes issue #115. 