### PR TITLE
High level API - ASCII mode transfer fixes

### DIFF
--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1169,9 +1169,9 @@ namespace FluentFTP {
 
 				// open a file connection
 				if (offset == 0) {
-					upStream = await OpenWriteAsync(remotePath);
+					upStream = await OpenWriteAsync(remotePath, UploadDataType);
 				} else {
-					upStream = await OpenAppendAsync(remotePath);
+					upStream = await OpenAppendAsync(remotePath, UploadDataType);
 				}
 
 				// loop till entire file uploaded
@@ -1599,7 +1599,7 @@ namespace FluentFTP {
 			try {
 
 				// exit if file length not available
-				downStream = OpenRead(remotePath);
+				downStream = OpenRead(remotePath, DownloadDataType);
 				long fileLen = downStream.Length;
 				if (fileLen == 0 && CurrentDataType == FtpDataType.ASCII) {
 
@@ -1763,7 +1763,7 @@ namespace FluentFTP {
 			Stream downStream = null;
 			try {
 				// exit if file length not available
-				downStream = await OpenReadAsync(remotePath);
+				downStream = await OpenReadAsync(remotePath, DownloadDataType);
 				long fileLen = downStream.Length;
 				if (fileLen == 0 && CurrentDataType == FtpDataType.ASCII) {
 					// close stream before throwing error


### PR DESCRIPTION
We found two issues with the high level transfer functions.   This pull request fixes both.

1.  The UploadDataType and DownloadDataType properties are ignored in most cases.   So, if you set the DownloadDataType to ASCII - the file will still download in Binary unless the server aborts the connection.  (then the retry will set the correct datatype).

**Fix:** Honor the Upload/DownloadDataType properties in all cases.

2. Unknown size ASCII files won't transfer.  Some of FTP servers won't allow you to download a 0 byte file in ASCII mode.  There's code in the high level methods to work around this issue - but it also blocks transfer of 'unknown size' files in ASCII mode.   This creates a problem since some systems don't support the 'SIZE' subcommand (AS400, possibly S390), but require that you download files in ASCII mode.   

**Fix:**  Force user to use BINARY mode for 'known 0 byte' files, but allow them to use ASCII mode if the server doesn't support the 'SIZE' subcommand.