### PR TITLE
Increase performance of GetListing method

### DIFF
--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -389,12 +389,9 @@ namespace FluentFTP {
 				using (FtpDataStream stream = OpenDataStream(listcmd, 0)) {
 					try {
 						FtpTrace.WriteLine(FtpTraceLevel.Verbose, "+---------------------------------------+");
-						while ((buf = stream.ReadLine(Encoding)) != null) {
-							if (buf.Length > 0) {
-								rawlisting.Add(buf);
-								FtpTrace.WriteLine(FtpTraceLevel.Verbose, "Listing:  " + buf);
-							}
-						}
+
+                        rawlisting = stream.ReadAllLines(Encoding).Where(l => l.Length > 0).ToList();
+
 						FtpTrace.WriteLine(FtpTraceLevel.Verbose, "-----------------------------------------");
 					} finally {
 						stream.Close();

--- a/FluentFTP/Client/FtpClient_Listing.cs
+++ b/FluentFTP/Client/FtpClient_Listing.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Globalization;
 using System.Security.Authentication;
@@ -390,7 +389,11 @@ namespace FluentFTP {
 					try {
 						FtpTrace.WriteLine(FtpTraceLevel.Verbose, "+---------------------------------------+");
 
-                        rawlisting = stream.ReadAllLines(Encoding).Where(l => l.Length > 0).ToList();
+                        foreach (var line in stream.ReadAllLines(Encoding))
+                        {
+                            if (!string.IsNullOrWhiteSpace(line))
+                                rawlisting.Add(line);
+                        }
 
 						FtpTrace.WriteLine(FtpTraceLevel.Verbose, "-----------------------------------------");
 					} finally {

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -520,12 +520,13 @@ namespace FluentFTP
 		/// Reads all line from the socket
 		/// </summary>
 		/// <param name="encoding">The type of encoding used to convert from byte[] to string</param>
+        /// <param name="bufferSize">The size of the buffer</param>
 		/// <returns>A list of lines from the stream</returns>
-		public IEnumerable<string> ReadAllLines(System.Text.Encoding encoding)
+		public IEnumerable<string> ReadAllLines(System.Text.Encoding encoding, int bufferSize)
         {
             int charRead;
             List<byte> data = new List<byte>();
-            byte[] buf = new byte[100]; //read 100 char
+            byte[] buf = new byte[bufferSize];
 
             while ((charRead = Read(buf, 0, buf.Length)) > 0)
             {

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
-using System.Linq;
 
 #if (CORE || NETFX45)
 using System.Threading.Tasks;
@@ -472,18 +471,18 @@ namespace FluentFTP {
                 
                 while(separatorIdx >= 0) // at least one '\n' returned
                 {
-                    data.AddRange(buf.Skip(firstByteToReadIdx).Take(separatorIdx+1 - firstByteToReadIdx)); // add characters to data till separator character
-
+                    while (firstByteToReadIdx <= separatorIdx)
+                        data.Add(buf[firstByteToReadIdx++]);
+                    
                     var line =  encoding.GetString(data.ToArray()).Trim('\r', '\n'); // convert data to string
                     yield return line;
                     data.Clear();
-
-                    firstByteToReadIdx = separatorIdx + 1;
+                    
                     separatorIdx = Array.IndexOf(buf, (byte)'\n', firstByteToReadIdx, charRead - firstByteToReadIdx); //search in full byte array readed
                 }
-                
-                data.AddRange(buf.Skip(firstByteToReadIdx).Take(charRead - firstByteToReadIdx)); // add all characters to data
-                
+
+                while (firstByteToReadIdx < charRead)  // add all remainings characters to data
+                    data.Add(buf[firstByteToReadIdx++]);
             }
         }
 

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -13,342 +13,400 @@ using System.Net;
 using System.Threading.Tasks;
 #endif
 
-namespace FluentFTP {
+namespace FluentFTP
+{
+    /// <summary>
+    /// Stream class used for talking. Used by FtpClient, extended by FtpDataStream
+    /// </summary>
+    public class FtpSocketStream : Stream, IDisposable
+    {
+        /// <summary>
+        /// Used for tacking read/write activity on the socket
+        /// to determine if Poll() should be used to test for
+        /// socket connectivity. The socket in this class will
+        /// not know it has been disconnected if the remote host
+        /// closes the connection first. Using Poll() avoids 
+        /// the exception that would be thrown when trying to
+        /// read or write to the disconnected socket.
+        /// </summary>
+        private DateTime m_lastActivity = DateTime.Now;
 
-	/// <summary>
-	/// Stream class used for talking. Used by FtpClient, extended by FtpDataStream
-	/// </summary>
-	public class FtpSocketStream : Stream, IDisposable {
-		/// <summary>
-		/// Used for tacking read/write activity on the socket
-		/// to determine if Poll() should be used to test for
-		/// socket connectivity. The socket in this class will
-		/// not know it has been disconnected if the remote host
-		/// closes the connection first. Using Poll() avoids 
-		/// the exception that would be thrown when trying to
-		/// read or write to the disconnected socket.
-		/// </summary>
-		private DateTime m_lastActivity = DateTime.Now;
+        private Socket m_socket = null;
+        /// <summary>
+        /// The socket used for talking
+        /// </summary>
+        protected Socket Socket
+        {
+            get
+            {
+                return m_socket;
+            }
+            private set
+            {
+                m_socket = value;
+            }
+        }
 
-		private Socket m_socket = null;
-		/// <summary>
-		/// The socket used for talking
-		/// </summary>
-		protected Socket Socket {
-			get {
-				return m_socket;
-			}
-			private set {
-				m_socket = value;
-			}
-		}
+        int m_socketPollInterval = 15000;
+        /// <summary>
+        /// Gets or sets the length of time in milliseconds
+        /// that must pass since the last socket activity
+        /// before calling Poll() on the socket to test for
+        /// connectivity. Setting this interval too low will
+        /// have a negative impact on performance. Setting this
+        /// interval to 0 disables Poll()'ing all together.
+        /// The default value is 15 seconds.
+        /// </summary>
+        public int SocketPollInterval
+        {
+            get { return m_socketPollInterval; }
+            set { m_socketPollInterval = value; }
+        }
 
-		int m_socketPollInterval = 15000;
-		/// <summary>
-		/// Gets or sets the length of time in milliseconds
-		/// that must pass since the last socket activity
-		/// before calling Poll() on the socket to test for
-		/// connectivity. Setting this interval too low will
-		/// have a negative impact on performance. Setting this
-		/// interval to 0 disables Poll()'ing all together.
-		/// The default value is 15 seconds.
-		/// </summary>
-		public int SocketPollInterval {
-			get { return m_socketPollInterval; }
-			set { m_socketPollInterval = value; }
-		}
+        /// <summary>
+        /// Gets the number of available bytes on the socket, 0 if the
+        /// socket has not been initialized. This property is used internally
+        /// by FtpClient in an effort to detect disconnections and gracefully
+        /// reconnect the control connection.
+        /// </summary>
+        internal int SocketDataAvailable
+        {
+            get
+            {
+                if (m_socket != null)
+                    return m_socket.Available;
+                return 0;
+            }
+        }
 
-		/// <summary>
-		/// Gets the number of available bytes on the socket, 0 if the
-		/// socket has not been initialized. This property is used internally
-		/// by FtpClient in an effort to detect disconnections and gracefully
-		/// reconnect the control connection.
-		/// </summary>
-		internal int SocketDataAvailable {
-			get {
-				if (m_socket != null)
-					return m_socket.Available;
-				return 0;
-			}
-		}
+        /// <summary>
+        /// Gets a value indicating if this socket stream is connected
+        /// </summary>
+        public bool IsConnected
+        {
+            get
+            {
+                try
+                {
+                    if (m_socket == null)
+                        return false;
 
-		/// <summary>
-		/// Gets a value indicating if this socket stream is connected
-		/// </summary>
-		public bool IsConnected {
-			get {
-				try {
-					if (m_socket == null)
-						return false;
+                    if (!m_socket.Connected)
+                    {
+                        Close();
+                        return false;
+                    }
 
-					if (!m_socket.Connected) {
-						Close();
-						return false;
-					}
+                    if (!CanRead || !CanWrite)
+                    {
+                        Close();
+                        return false;
+                    }
 
-					if (!CanRead || !CanWrite) {
-						Close();
-						return false;
-					}
+                    if (m_socketPollInterval > 0 && DateTime.Now.Subtract(m_lastActivity).TotalMilliseconds > m_socketPollInterval)
+                    {
+                        FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Testing connectivity using Socket.Poll()...");
+                        if (m_socket.Poll(500000, SelectMode.SelectRead) && m_socket.Available == 0)
+                        {
+                            Close();
+                            return false;
+                        }
+                    }
+                }
+                catch (SocketException sockex)
+                {
+                    Close();
+                    FtpTrace.WriteStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded SocketException while testing for connectivity: " + sockex.ToString());
+                    return false;
+                }
+                catch (IOException ioex)
+                {
+                    Close();
+                    FtpTrace.WriteStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded IOException while testing for connectivity: " + ioex.ToString());
+                    return false;
+                }
 
-					if (m_socketPollInterval > 0 && DateTime.Now.Subtract(m_lastActivity).TotalMilliseconds > m_socketPollInterval) {
-						FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Testing connectivity using Socket.Poll()...");
-						if (m_socket.Poll(500000, SelectMode.SelectRead) && m_socket.Available == 0) {
-							Close();
-							return false;
-						}
-					}
-				} catch (SocketException sockex) {
-					Close();
-					FtpTrace.WriteStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded SocketException while testing for connectivity: " + sockex.ToString());
-					return false;
-				} catch (IOException ioex) {
-					Close();
-					FtpTrace.WriteStatus(FtpTraceLevel.Warn, "FtpSocketStream.IsConnected: Caught and discarded IOException while testing for connectivity: " + ioex.ToString());
-					return false;
-				}
+                return true;
+            }
+        }
 
-				return true;
-			}
-		}
-
-		/// <summary>
-		/// Gets a value indicating if encryption is being used
-		/// </summary>
-		public bool IsEncrypted {
-			get {
+        /// <summary>
+        /// Gets a value indicating if encryption is being used
+        /// </summary>
+        public bool IsEncrypted
+        {
+            get
+            {
 #if NO_SSL
 				return false;
 #else
-				return m_sslStream != null;
+                return m_sslStream != null;
 #endif
-			}
-		}
+            }
+        }
 
-		NetworkStream m_netStream = null;
-		/// <summary>
-		/// The non-encrypted stream
-		/// </summary>
-		private NetworkStream NetworkStream {
-			get {
-				return m_netStream;
-			}
-			set {
-				m_netStream = value;
-			}
-		}
+        NetworkStream m_netStream = null;
+        /// <summary>
+        /// The non-encrypted stream
+        /// </summary>
+        private NetworkStream NetworkStream
+        {
+            get
+            {
+                return m_netStream;
+            }
+            set
+            {
+                m_netStream = value;
+            }
+        }
 
 #if !NO_SSL
-		SslStream m_sslStream = null;
-		/// <summary>
-		/// The encrypted stream
-		/// </summary>
-		private SslStream SslStream {
-			get {
-				return m_sslStream;
-			}
-			set {
-				m_sslStream = value;
-			}
-		}
+        SslStream m_sslStream = null;
+        /// <summary>
+        /// The encrypted stream
+        /// </summary>
+        private SslStream SslStream
+        {
+            get
+            {
+                return m_sslStream;
+            }
+            set
+            {
+                m_sslStream = value;
+            }
+        }
 #endif
 
-		/// <summary>
-		/// Gets the underlying stream, could be a NetworkStream or SslStream
-		/// </summary>
-		protected Stream BaseStream {
-			get {
+        /// <summary>
+        /// Gets the underlying stream, could be a NetworkStream or SslStream
+        /// </summary>
+        protected Stream BaseStream
+        {
+            get
+            {
 #if NO_SSL
 				if (m_netStream != null)
 					return m_netStream;
 #else
-				if (m_sslStream != null)
-					return m_sslStream;
-				else if (m_netStream != null)
-					return m_netStream;
+                if (m_sslStream != null)
+                    return m_sslStream;
+                else if (m_netStream != null)
+                    return m_netStream;
 #endif
 
-				return null;
-			}
-		}
+                return null;
+            }
+        }
 
-		/// <summary>
-		/// Gets a value indicating if this stream can be read
-		/// </summary>
-		public override bool CanRead {
-			get {
-				if (m_netStream != null)
-					return m_netStream.CanRead;
-				return false;
-			}
-		}
+        /// <summary>
+        /// Gets a value indicating if this stream can be read
+        /// </summary>
+        public override bool CanRead
+        {
+            get
+            {
+                if (m_netStream != null)
+                    return m_netStream.CanRead;
+                return false;
+            }
+        }
 
-		/// <summary>
-		/// Gets a value indicating if this stream if seekable
-		/// </summary>
-		public override bool CanSeek {
-			get {
-				return false;
-			}
-		}
+        /// <summary>
+        /// Gets a value indicating if this stream if seekable
+        /// </summary>
+        public override bool CanSeek
+        {
+            get
+            {
+                return false;
+            }
+        }
 
-		/// <summary>
-		/// Gets a value indicating if this stream can be written to
-		/// </summary>
-		public override bool CanWrite {
-			get {
-				if (m_netStream != null)
-					return m_netStream.CanWrite;
+        /// <summary>
+        /// Gets a value indicating if this stream can be written to
+        /// </summary>
+        public override bool CanWrite
+        {
+            get
+            {
+                if (m_netStream != null)
+                    return m_netStream.CanWrite;
 
-				return false;
-			}
-		}
+                return false;
+            }
+        }
 
-		/// <summary>
-		/// Gets the length of the stream
-		/// </summary>
-		public override long Length {
-			get {
-				return 0;
-			}
-		}
+        /// <summary>
+        /// Gets the length of the stream
+        /// </summary>
+        public override long Length
+        {
+            get
+            {
+                return 0;
+            }
+        }
 
-		/// <summary>
-		/// Gets the current position of the stream. Trying to
-		/// set this property throws an InvalidOperationException()
-		/// </summary>
-		public override long Position {
-			get {
-				if (BaseStream != null)
-					return BaseStream.Position;
-				return 0;
-			}
-			set {
-				throw new InvalidOperationException();
-			}
-		}
+        /// <summary>
+        /// Gets the current position of the stream. Trying to
+        /// set this property throws an InvalidOperationException()
+        /// </summary>
+        public override long Position
+        {
+            get
+            {
+                if (BaseStream != null)
+                    return BaseStream.Position;
+                return 0;
+            }
+            set
+            {
+                throw new InvalidOperationException();
+            }
+        }
 
-		event FtpSocketStreamSslValidation m_sslvalidate = null;
-		/// <summary>
-		/// Event is fired when a SSL certificate needs to be validated
-		/// </summary>
-		public event FtpSocketStreamSslValidation ValidateCertificate {
-			add {
-				m_sslvalidate += value;
-			}
-			remove {
-				m_sslvalidate -= value;
-			}
-		}
+        event FtpSocketStreamSslValidation m_sslvalidate = null;
+        /// <summary>
+        /// Event is fired when a SSL certificate needs to be validated
+        /// </summary>
+        public event FtpSocketStreamSslValidation ValidateCertificate
+        {
+            add
+            {
+                m_sslvalidate += value;
+            }
+            remove
+            {
+                m_sslvalidate -= value;
+            }
+        }
 
-		int m_readTimeout = Timeout.Infinite;
-		/// <summary>
-		/// Gets or sets the amount of time to wait for a read operation to complete. Default
-		/// value is Timeout.Infinite.
-		/// </summary>
-		public override int ReadTimeout {
-			get {
-				return m_readTimeout;
-			}
-			set {
-				m_readTimeout = value;
-			}
-		}
+        int m_readTimeout = Timeout.Infinite;
+        /// <summary>
+        /// Gets or sets the amount of time to wait for a read operation to complete. Default
+        /// value is Timeout.Infinite.
+        /// </summary>
+        public override int ReadTimeout
+        {
+            get
+            {
+                return m_readTimeout;
+            }
+            set
+            {
+                m_readTimeout = value;
+            }
+        }
 
-		int m_connectTimeout = 30000;
-		/// <summary>
-		/// Gets or sets the length of time milliseconds to wait
-		/// for a connection succeed before giving up. The default
-		/// is 30000 (30 seconds).
-		/// </summary>
-		public int ConnectTimeout {
-			get {
-				return m_connectTimeout;
-			}
-			set {
-				m_connectTimeout = value;
-			}
-		}
+        int m_connectTimeout = 30000;
+        /// <summary>
+        /// Gets or sets the length of time milliseconds to wait
+        /// for a connection succeed before giving up. The default
+        /// is 30000 (30 seconds).
+        /// </summary>
+        public int ConnectTimeout
+        {
+            get
+            {
+                return m_connectTimeout;
+            }
+            set
+            {
+                m_connectTimeout = value;
+            }
+        }
 
-		/// <summary>
-		/// Gets the local end point of the socket
-		/// </summary>
-		public IPEndPoint LocalEndPoint {
-			get {
-				if (m_socket == null)
-					return null;
-				return (IPEndPoint)m_socket.LocalEndPoint;
-			}
-		}
+        /// <summary>
+        /// Gets the local end point of the socket
+        /// </summary>
+        public IPEndPoint LocalEndPoint
+        {
+            get
+            {
+                if (m_socket == null)
+                    return null;
+                return (IPEndPoint)m_socket.LocalEndPoint;
+            }
+        }
 
-		/// <summary>
-		/// Gets the remote end point of the socket
-		/// </summary>
-		public IPEndPoint RemoteEndPoint {
-			get {
-				if (m_socket == null)
-					return null;
-				return (IPEndPoint)m_socket.RemoteEndPoint;
-			}
-		}
+        /// <summary>
+        /// Gets the remote end point of the socket
+        /// </summary>
+        public IPEndPoint RemoteEndPoint
+        {
+            get
+            {
+                if (m_socket == null)
+                    return null;
+                return (IPEndPoint)m_socket.RemoteEndPoint;
+            }
+        }
 
-		/// <summary>
-		/// Fires the SSL certificate validation event
-		/// </summary>
-		/// <param name="certificate">Certificate being validated</param>
-		/// <param name="chain">Certificate chain</param>
-		/// <param name="errors">Policy errors if any</param>
-		/// <returns>True if it was accepted, false otherwise</returns>
-		protected bool OnValidateCertificate(X509Certificate certificate, X509Chain chain, SslPolicyErrors errors) {
-			FtpSocketStreamSslValidation evt = m_sslvalidate;
+        /// <summary>
+        /// Fires the SSL certificate validation event
+        /// </summary>
+        /// <param name="certificate">Certificate being validated</param>
+        /// <param name="chain">Certificate chain</param>
+        /// <param name="errors">Policy errors if any</param>
+        /// <returns>True if it was accepted, false otherwise</returns>
+        protected bool OnValidateCertificate(X509Certificate certificate, X509Chain chain, SslPolicyErrors errors)
+        {
+            FtpSocketStreamSslValidation evt = m_sslvalidate;
 
-			if (evt != null) {
-				FtpSslValidationEventArgs e = new FtpSslValidationEventArgs() {
-					Certificate = certificate,
-					Chain = chain,
-					PolicyErrors = errors,
-					Accept = (errors == SslPolicyErrors.None)
-				};
+            if (evt != null)
+            {
+                FtpSslValidationEventArgs e = new FtpSslValidationEventArgs()
+                {
+                    Certificate = certificate,
+                    Chain = chain,
+                    PolicyErrors = errors,
+                    Accept = (errors == SslPolicyErrors.None)
+                };
 
-				evt(this, e);
-				return e.Accept;
-			}
+                evt(this, e);
+                return e.Accept;
+            }
 
-			// if the event was not handled then only accept
-			// the certificate if there were no validation errors
-			return (errors == SslPolicyErrors.None);
-		}
+            // if the event was not handled then only accept
+            // the certificate if there were no validation errors
+            return (errors == SslPolicyErrors.None);
+        }
 
-		/// <summary>
-		/// Throws an InvalidOperationException
-		/// </summary>
-		/// <param name="offset">Ignored</param>
-		/// <param name="origin">Ignored</param>
-		/// <returns></returns>
-		public override long Seek(long offset, SeekOrigin origin) {
-			throw new InvalidOperationException();
-		}
+        /// <summary>
+        /// Throws an InvalidOperationException
+        /// </summary>
+        /// <param name="offset">Ignored</param>
+        /// <param name="origin">Ignored</param>
+        /// <returns></returns>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new InvalidOperationException();
+        }
 
-		/// <summary>
-		/// Throws an InvalidOperationException
-		/// </summary>
-		/// <param name="value">Ignored</param>
-		public override void SetLength(long value) {
-			throw new InvalidOperationException();
-		}
+        /// <summary>
+        /// Throws an InvalidOperationException
+        /// </summary>
+        /// <param name="value">Ignored</param>
+        public override void SetLength(long value)
+        {
+            throw new InvalidOperationException();
+        }
 
-		/// <summary>
-		/// Flushes the stream
-		/// </summary>
-		public override void Flush() {
-			if (!IsConnected)
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
+        /// <summary>
+        /// Flushes the stream
+        /// </summary>
+        public override void Flush()
+        {
+            if (!IsConnected)
+                throw new InvalidOperationException("The FtpSocketStream object is not connected.");
 
-			if (BaseStream == null)
-				throw new InvalidOperationException("The base stream of the FtpSocketStream object is null.");
+            if (BaseStream == null)
+                throw new InvalidOperationException("The base stream of the FtpSocketStream object is null.");
 
-			BaseStream.Flush();
-		}
+            BaseStream.Flush();
+        }
 
 #if (CORE || NETFX45)
 
@@ -368,48 +426,52 @@ namespace FluentFTP {
 
 #endif
 
-		/// <summary>
-		/// Bypass the stream and read directly off the socket.
-		/// </summary>
-		/// <param name="buffer">The buffer to read into</param>
-		/// <returns>The number of bytes read</returns>
-		internal int RawSocketRead(byte[] buffer) {
-			int read = 0;
+        /// <summary>
+        /// Bypass the stream and read directly off the socket.
+        /// </summary>
+        /// <param name="buffer">The buffer to read into</param>
+        /// <returns>The number of bytes read</returns>
+        internal int RawSocketRead(byte[] buffer)
+        {
+            int read = 0;
 
-			if (m_socket != null && m_socket.Connected) {
-				read = m_socket.Receive(buffer, buffer.Length, 0);
-			}
+            if (m_socket != null && m_socket.Connected)
+            {
+                read = m_socket.Receive(buffer, buffer.Length, 0);
+            }
 
-			return read;
-		}
+            return read;
+        }
 
-		/// <summary>
-		/// Reads data from the stream
-		/// </summary>
-		/// <param name="buffer">Buffer to read into</param>
-		/// <param name="offset">Where in the buffer to start</param>
-		/// <param name="count">Number of bytes to be read</param>
-		/// <returns>The amount of bytes read from the stream</returns>
-		public override int Read(byte[] buffer, int offset, int count) {
+        /// <summary>
+        /// Reads data from the stream
+        /// </summary>
+        /// <param name="buffer">Buffer to read into</param>
+        /// <param name="offset">Where in the buffer to start</param>
+        /// <param name="count">Number of bytes to be read</param>
+        /// <returns>The amount of bytes read from the stream</returns>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
 #if !CORE
-			IAsyncResult ar = null;
+            IAsyncResult ar = null;
 #endif
 
-			if (BaseStream == null)
-				return 0;
+            if (BaseStream == null)
+                return 0;
 
-			m_lastActivity = DateTime.Now;
+            m_lastActivity = DateTime.Now;
 #if CORE
 			return BaseStream.ReadAsync(buffer, offset, count).Result;
 #else
-			ar = BaseStream.BeginRead(buffer, offset, count, null, null);
-			if (!ar.AsyncWaitHandle.WaitOne(m_readTimeout, true)) {
-				Close();
-				throw new TimeoutException("Timed out trying to read data from the socket stream!");
-			}
-			return BaseStream.EndRead(ar);
+            ar = BaseStream.BeginRead(buffer, offset, count, null, null);
+            if (!ar.AsyncWaitHandle.WaitOne(m_readTimeout, true))
+            {
+                Close();
+                throw new TimeoutException("Timed out trying to read data from the socket stream!");
+            }
+            return BaseStream.EndRead(ar);
 #endif
-		}
+        }
 
 #if (CORE || NETFX45)
 
@@ -430,26 +492,29 @@ namespace FluentFTP {
 		}
 #endif
 
-		/// <summary>
-		/// Reads a line from the socket
-		/// </summary>
-		/// <param name="encoding">The type of encoding used to convert from byte[] to string</param>
-		/// <returns>A line from the stream, null if there is nothing to read</returns>
-		public string ReadLine(System.Text.Encoding encoding) {
-			List<byte> data = new List<byte>();
-			byte[] buf = new byte[1];
-			string line = null;
+        /// <summary>
+        /// Reads a line from the socket
+        /// </summary>
+        /// <param name="encoding">The type of encoding used to convert from byte[] to string</param>
+        /// <returns>A line from the stream, null if there is nothing to read</returns>
+        public string ReadLine(System.Text.Encoding encoding)
+        {
+            List<byte> data = new List<byte>();
+            byte[] buf = new byte[1];
+            string line = null;
 
-			while (Read(buf, 0, buf.Length) > 0) {
-				data.Add(buf[0]);
-				if ((char)buf[0] == '\n') {
-					line = encoding.GetString(data.ToArray()).Trim('\r', '\n');
-					break;
-				}
-			}
+            while (Read(buf, 0, buf.Length) > 0)
+            {
+                data.Add(buf[0]);
+                if ((char)buf[0] == '\n')
+                {
+                    line = encoding.GetString(data.ToArray()).Trim('\r', '\n');
+                    break;
+                }
+            }
 
-			return line;
-		}
+            return line;
+        }
 
         /// <summary>
 		/// Reads all line from the socket
@@ -460,24 +525,23 @@ namespace FluentFTP {
         {
             int charRead;
             List<byte> data = new List<byte>();
-            byte[] buf = new byte[100]; //read 50 char
+            byte[] buf = new byte[100]; //read 100 char
 
             while ((charRead = Read(buf, 0, buf.Length)) > 0)
             {
                 var firstByteToReadIdx = 0;
 
                 var separatorIdx = Array.IndexOf(buf, (byte)'\n', firstByteToReadIdx, charRead - firstByteToReadIdx); //search in full byte array readed
-               
-                
-                while(separatorIdx >= 0) // at least one '\n' returned
+
+                while (separatorIdx >= 0) // at least one '\n' returned
                 {
                     while (firstByteToReadIdx <= separatorIdx)
                         data.Add(buf[firstByteToReadIdx++]);
-                    
-                    var line =  encoding.GetString(data.ToArray()).Trim('\r', '\n'); // convert data to string
+
+                    var line = encoding.GetString(data.ToArray()).Trim('\r', '\n'); // convert data to string
                     yield return line;
                     data.Clear();
-                    
+
                     separatorIdx = Array.IndexOf(buf, (byte)'\n', firstByteToReadIdx, charRead - firstByteToReadIdx); //search in full byte array readed
                 }
 
@@ -519,19 +583,20 @@ namespace FluentFTP {
 		}
 #endif
 
-		/// <summary>
-		/// Writes data to the stream
-		/// </summary>
-		/// <param name="buffer">Buffer to write to stream</param>
-		/// <param name="offset">Where in the buffer to start</param>
-		/// <param name="count">Number of bytes to be read</param>
-		public override void Write(byte[] buffer, int offset, int count) {
-			if (BaseStream == null)
-				return;
+        /// <summary>
+        /// Writes data to the stream
+        /// </summary>
+        /// <param name="buffer">Buffer to write to stream</param>
+        /// <param name="offset">Where in the buffer to start</param>
+        /// <param name="count">Number of bytes to be read</param>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (BaseStream == null)
+                return;
 
-			BaseStream.Write(buffer, offset, count);
-			m_lastActivity = DateTime.Now;
-		}
+            BaseStream.Write(buffer, offset, count);
+            m_lastActivity = DateTime.Now;
+        }
 
 #if (CORE || NETFX45)
 		/// <summary>
@@ -550,16 +615,17 @@ namespace FluentFTP {
 		}
 #endif
 
-		/// <summary>
-		/// Writes a line to the stream using the specified encoding
-		/// </summary>
-		/// <param name="encoding">Encoding used for writing the line</param>
-		/// <param name="buf">The data to write</param>
-		public void WriteLine(System.Text.Encoding encoding, string buf) {
-			byte[] data;
-			data = encoding.GetBytes((buf + "\r\n"));
-			Write(data, 0, data.Length);
-		}
+        /// <summary>
+        /// Writes a line to the stream using the specified encoding
+        /// </summary>
+        /// <param name="encoding">Encoding used for writing the line</param>
+        /// <param name="buf">The data to write</param>
+        public void WriteLine(System.Text.Encoding encoding, string buf)
+        {
+            byte[] data;
+            data = encoding.GetBytes((buf + "\r\n"));
+            Write(data, 0, data.Length);
+        }
 
 #if (CORE || NETFX45)
 		/// <summary>
@@ -583,218 +649,257 @@ namespace FluentFTP {
 		}
 #endif
 
-		/// <summary>
-		/// Disposes the stream
-		/// </summary>
-		public new void Dispose() {
-			FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
-			Close();
-		}
+        /// <summary>
+        /// Disposes the stream
+        /// </summary>
+        public new void Dispose()
+        {
+            FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
+            Close();
+        }
 
-		/// <summary>
-		/// Disconnects from server
-		/// </summary>
+        /// <summary>
+        /// Disconnects from server
+        /// </summary>
 #if CORE
 		public void Close() {
 #else
-		public override void Close() {
+        public override void Close()
+        {
 #endif
-			if (m_socket != null) {
-				try {
-					if (m_socket.Connected) {
-						////
-						// Calling Shutdown() with mono causes an
-						// exception if the remote host closed first
-						//m_socket.Shutdown(SocketShutdown.Both);
+            if (m_socket != null)
+            {
+                try
+                {
+                    if (m_socket.Connected)
+                    {
+                        ////
+                        // Calling Shutdown() with mono causes an
+                        // exception if the remote host closed first
+                        //m_socket.Shutdown(SocketShutdown.Both);
 #if CORE
 						m_socket.Dispose();
 #else
-						m_socket.Close();
+                        m_socket.Close();
 #endif
-					}
+                    }
 
 #if !NET2 && !NET35
-					m_socket.Dispose();
+                    m_socket.Dispose();
 #endif
                 }
-                catch (SocketException ex) {
-					FtpTrace.WriteStatus(FtpTraceLevel.Warn, "Caught and discarded a SocketException while cleaning up the Socket: " + ex.ToString());
-				} finally {
-					m_socket = null;
-				}
-			}
+                catch (SocketException ex)
+                {
+                    FtpTrace.WriteStatus(FtpTraceLevel.Warn, "Caught and discarded a SocketException while cleaning up the Socket: " + ex.ToString());
+                }
+                finally
+                {
+                    m_socket = null;
+                }
+            }
 
-			if (m_netStream != null) {
-				try {
-					m_netStream.Dispose();
-				} catch (IOException ex) {
-					FtpTrace.WriteStatus(FtpTraceLevel.Warn, "Caught and discarded an IOException while cleaning up the NetworkStream: " + ex.ToString());
-				} finally {
-					m_netStream = null;
-				}
-			}
+            if (m_netStream != null)
+            {
+                try
+                {
+                    m_netStream.Dispose();
+                }
+                catch (IOException ex)
+                {
+                    FtpTrace.WriteStatus(FtpTraceLevel.Warn, "Caught and discarded an IOException while cleaning up the NetworkStream: " + ex.ToString());
+                }
+                finally
+                {
+                    m_netStream = null;
+                }
+            }
 
 #if !NO_SSL
-			if (m_sslStream != null) {
-				try {
-					m_sslStream.Dispose();
-				} catch (IOException ex) {
-					FtpTrace.WriteStatus(FtpTraceLevel.Warn, "Caught and discarded an IOException while cleaning up the SslStream: " + ex.ToString());
-				} finally {
-					m_sslStream = null;
-				}
-			}
+            if (m_sslStream != null)
+            {
+                try
+                {
+                    m_sslStream.Dispose();
+                }
+                catch (IOException ex)
+                {
+                    FtpTrace.WriteStatus(FtpTraceLevel.Warn, "Caught and discarded an IOException while cleaning up the SslStream: " + ex.ToString());
+                }
+                finally
+                {
+                    m_sslStream = null;
+                }
+            }
 #endif
 
 #if CORE
             base.Dispose();
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Sets socket options on the underlying socket
-		/// </summary>
-		/// <param name="level">SocketOptionLevel</param>
-		/// <param name="name">SocketOptionName</param>
-		/// <param name="value">SocketOptionValue</param>
-		public void SetSocketOption(SocketOptionLevel level, SocketOptionName name, bool value) {
-			if (m_socket == null)
-				throw new InvalidOperationException("The underlying socket is null. Have you established a connection?");
-			m_socket.SetSocketOption(level, name, value);
-		}
+        /// <summary>
+        /// Sets socket options on the underlying socket
+        /// </summary>
+        /// <param name="level">SocketOptionLevel</param>
+        /// <param name="name">SocketOptionName</param>
+        /// <param name="value">SocketOptionValue</param>
+        public void SetSocketOption(SocketOptionLevel level, SocketOptionName name, bool value)
+        {
+            if (m_socket == null)
+                throw new InvalidOperationException("The underlying socket is null. Have you established a connection?");
+            m_socket.SetSocketOption(level, name, value);
+        }
 
-		/// <summary>
-		/// Connect to the specified host
-		/// </summary>
-		/// <param name="host">The host to connect to</param>
-		/// <param name="port">The port to connect to</param>
-		/// <param name="ipVersions">Internet Protocol versions to support during the connection phase</param>
-		public void Connect(string host, int port, FtpIpVersion ipVersions) {
+        /// <summary>
+        /// Connect to the specified host
+        /// </summary>
+        /// <param name="host">The host to connect to</param>
+        /// <param name="port">The port to connect to</param>
+        /// <param name="ipVersions">Internet Protocol versions to support during the connection phase</param>
+        public void Connect(string host, int port, FtpIpVersion ipVersions)
+        {
 #if CORE
 			IPAddress[] addresses = Dns.GetHostAddressesAsync(host).Result;
 #else
-			IAsyncResult ar = null;
-			IPAddress[] addresses = Dns.GetHostAddresses(host);
+            IAsyncResult ar = null;
+            IPAddress[] addresses = Dns.GetHostAddresses(host);
 #endif
 
-			if (ipVersions == 0)
-				throw new ArgumentException("The ipVersions parameter must contain at least 1 flag.");
+            if (ipVersions == 0)
+                throw new ArgumentException("The ipVersions parameter must contain at least 1 flag.");
 
-			for (int i = 0; i < addresses.Length; i++) {
-				// we don't need to do this check unless
-				// a particular version of IP has been
-				// omitted so we won't.
-				if (ipVersions != FtpIpVersion.ANY) {
-					switch (addresses[i].AddressFamily) {
-						case AddressFamily.InterNetwork:
-							if ((ipVersions & FtpIpVersion.IPv4) != FtpIpVersion.IPv4) {
+            for (int i = 0; i < addresses.Length; i++)
+            {
+                // we don't need to do this check unless
+                // a particular version of IP has been
+                // omitted so we won't.
+                if (ipVersions != FtpIpVersion.ANY)
+                {
+                    switch (addresses[i].AddressFamily)
+                    {
+                        case AddressFamily.InterNetwork:
+                            if ((ipVersions & FtpIpVersion.IPv4) != FtpIpVersion.IPv4)
+                            {
 #if DEBUG
 								FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Skipped IPV4 address : " + addresses[i].ToString());
 #endif
-								continue;
-							}
-							break;
-						case AddressFamily.InterNetworkV6:
-							if ((ipVersions & FtpIpVersion.IPv6) != FtpIpVersion.IPv6) {
+                                continue;
+                            }
+                            break;
+                        case AddressFamily.InterNetworkV6:
+                            if ((ipVersions & FtpIpVersion.IPv6) != FtpIpVersion.IPv6)
+                            {
 #if DEBUG
 								FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Skipped IPV6 address : " + addresses[i].ToString());
 #endif
-								continue;
-							}
-							break;
-					}
-				}
+                                continue;
+                            }
+                            break;
+                    }
+                }
 
-				if (FtpTrace.LogIP) {
-					FtpTrace.WriteStatus(FtpTraceLevel.Info, "Connecting to " + addresses[i].ToString() + ":" + port);
-				} else {
-					FtpTrace.WriteStatus(FtpTraceLevel.Info, "Connecting to ***:" + port);
-				}
+                if (FtpTrace.LogIP)
+                {
+                    FtpTrace.WriteStatus(FtpTraceLevel.Info, "Connecting to " + addresses[i].ToString() + ":" + port);
+                }
+                else
+                {
+                    FtpTrace.WriteStatus(FtpTraceLevel.Info, "Connecting to ***:" + port);
+                }
 
-				m_socket = new Socket(addresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                m_socket = new Socket(addresses[i].AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 #if CORE
 				m_socket.ConnectAsync(addresses[i], port).Wait();
 #else
-				ar = m_socket.BeginConnect(addresses[i], port, null, null);
-				if (!ar.AsyncWaitHandle.WaitOne(m_connectTimeout, true)) {
-					Close();
+                ar = m_socket.BeginConnect(addresses[i], port, null, null);
+                if (!ar.AsyncWaitHandle.WaitOne(m_connectTimeout, true))
+                {
+                    Close();
 
-					// check to see if we're out of addresses, and throw a TimeoutException
-					if ((i + 1) == addresses.Length) {
-						throw new TimeoutException("Timed out trying to connect!");
-					}
-				} else {
-					m_socket.EndConnect(ar);
-					// we got a connection, break out
-					// of the loop.
-					break;
-				}
+                    // check to see if we're out of addresses, and throw a TimeoutException
+                    if ((i + 1) == addresses.Length)
+                    {
+                        throw new TimeoutException("Timed out trying to connect!");
+                    }
+                }
+                else
+                {
+                    m_socket.EndConnect(ar);
+                    // we got a connection, break out
+                    // of the loop.
+                    break;
+                }
 #endif
-			}
+            }
 
-			// make sure that we actually connected to
-			// one of the addresses returned from GetHostAddresses()
-			if (m_socket == null || !m_socket.Connected) {
-				Close();
-				throw new IOException("Failed to connect to host.");
-			}
+            // make sure that we actually connected to
+            // one of the addresses returned from GetHostAddresses()
+            if (m_socket == null || !m_socket.Connected)
+            {
+                Close();
+                throw new IOException("Failed to connect to host.");
+            }
 
-			m_netStream = new NetworkStream(m_socket);
-			m_lastActivity = DateTime.Now;
-		}
+            m_netStream = new NetworkStream(m_socket);
+            m_lastActivity = DateTime.Now;
+        }
 
 #if !NO_SSL
-		/// <summary>
-		/// Activates SSL on this stream using default protocols. Fires the ValidateCertificate event. 
-		/// If this event is not handled and there are SslPolicyErrors present, the certificate will 
-		/// not be accepted.
-		/// </summary>
-		/// <param name="targethost">The host to authenticate the certificate against</param>
-		public void ActivateEncryption(string targethost) {
+        /// <summary>
+        /// Activates SSL on this stream using default protocols. Fires the ValidateCertificate event. 
+        /// If this event is not handled and there are SslPolicyErrors present, the certificate will 
+        /// not be accepted.
+        /// </summary>
+        /// <param name="targethost">The host to authenticate the certificate against</param>
+        public void ActivateEncryption(string targethost)
+        {
 #if CORE
 			ActivateEncryption(targethost, null, SslProtocols.Tls11 | SslProtocols.Ssl3);
 #else
-			ActivateEncryption(targethost, null, SslProtocols.Default);
+            ActivateEncryption(targethost, null, SslProtocols.Default);
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Activates SSL on this stream using default protocols. Fires the ValidateCertificate event.
-		/// If this event is not handled and there are SslPolicyErrors present, the certificate will 
-		/// not be accepted.
-		/// </summary>
-		/// <param name="targethost">The host to authenticate the certificate against</param>
-		/// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
-		public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts) {
+        /// <summary>
+        /// Activates SSL on this stream using default protocols. Fires the ValidateCertificate event.
+        /// If this event is not handled and there are SslPolicyErrors present, the certificate will 
+        /// not be accepted.
+        /// </summary>
+        /// <param name="targethost">The host to authenticate the certificate against</param>
+        /// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
+        public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts)
+        {
 #if CORE
 			ActivateEncryption(targethost, clientCerts, SslProtocols.Tls11 | SslProtocols.Ssl3);
 #else
-			ActivateEncryption(targethost, clientCerts, SslProtocols.Default);
+            ActivateEncryption(targethost, clientCerts, SslProtocols.Default);
 #endif
-		}
+        }
 
-		/// <summary>
-		/// Activates SSL on this stream using the specified protocols. Fires the ValidateCertificate event.
-		/// If this event is not handled and there are SslPolicyErrors present, the certificate will 
-		/// not be accepted.
-		/// </summary>
-		/// <param name="targethost">The host to authenticate the certificate against</param>
-		/// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
-		/// <param name="sslProtocols">A bitwise parameter for supported encryption protocols.</param>
-		/// <exception cref="AuthenticationException">Thrown when authentication fails</exception>
-		public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts, SslProtocols sslProtocols) {
-			if (!IsConnected)
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
+        /// <summary>
+        /// Activates SSL on this stream using the specified protocols. Fires the ValidateCertificate event.
+        /// If this event is not handled and there are SslPolicyErrors present, the certificate will 
+        /// not be accepted.
+        /// </summary>
+        /// <param name="targethost">The host to authenticate the certificate against</param>
+        /// <param name="clientCerts">A collection of client certificates to use when authenticating the SSL stream</param>
+        /// <param name="sslProtocols">A bitwise parameter for supported encryption protocols.</param>
+        /// <exception cref="AuthenticationException">Thrown when authentication fails</exception>
+        public void ActivateEncryption(string targethost, X509CertificateCollection clientCerts, SslProtocols sslProtocols)
+        {
+            if (!IsConnected)
+                throw new InvalidOperationException("The FtpSocketStream object is not connected.");
 
-			if (m_netStream == null)
-				throw new InvalidOperationException("The base network stream is null.");
+            if (m_netStream == null)
+                throw new InvalidOperationException("The base network stream is null.");
 
-			if (m_sslStream != null)
-				throw new InvalidOperationException("SSL Encryption has already been enabled on this stream.");
+            if (m_sslStream != null)
+                throw new InvalidOperationException("SSL Encryption has already been enabled on this stream.");
 
-			try {
-				DateTime auth_start;
-				TimeSpan auth_time_total;
+            try
+            {
+                DateTime auth_start;
+                TimeSpan auth_time_total;
 
 #if CORE
 				m_sslStream = new SslStream(NetworkStream, true, new RemoteCertificateValidationCallback(
@@ -803,74 +908,80 @@ namespace FluentFTP {
 					}
 				));
 #else
-				m_sslStream = new FtpSslStream(NetworkStream, true, new RemoteCertificateValidationCallback(
-					delegate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) {
-						return OnValidateCertificate(certificate, chain, sslPolicyErrors);
-					}
-				));
+                m_sslStream = new FtpSslStream(NetworkStream, true, new RemoteCertificateValidationCallback(
+                    delegate (object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+                    {
+                        return OnValidateCertificate(certificate, chain, sslPolicyErrors);
+                    }
+                ));
 #endif
 
-				auth_start = DateTime.Now;
+                auth_start = DateTime.Now;
 #if CORE
 				m_sslStream.AuthenticateAsClientAsync(targethost, clientCerts, sslProtocols, true).Wait();
 #else
-				m_sslStream.AuthenticateAsClient(targethost, clientCerts, sslProtocols, true);
+                m_sslStream.AuthenticateAsClient(targethost, clientCerts, sslProtocols, true);
 #endif
 
-				auth_time_total = DateTime.Now.Subtract(auth_start);
-				FtpTrace.WriteStatus(FtpTraceLevel.Info, "FTPS Authentication Successful");
-				FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Time to activate encryption: " + auth_time_total.Hours + "h " + auth_time_total.Minutes + "m " + auth_time_total.Seconds + "s.  Total Seconds: " + auth_time_total.TotalSeconds + ".");
-
-			} catch (AuthenticationException) {
-				// authentication failed and in addition it left our 
-				// ssl stream in an unusable state so cleanup needs
-				// to be done and the exception can be re-thrown for
-				// handling down the chain. (Add logging?)
-				Close();
-				FtpTrace.WriteStatus(FtpTraceLevel.Error, "FTPS Authentication Failed");
-				throw;
-			}
-		}
+                auth_time_total = DateTime.Now.Subtract(auth_start);
+                FtpTrace.WriteStatus(FtpTraceLevel.Info, "FTPS Authentication Successful");
+                FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Time to activate encryption: " + auth_time_total.Hours + "h " + auth_time_total.Minutes + "m " + auth_time_total.Seconds + "s.  Total Seconds: " + auth_time_total.TotalSeconds + ".");
+            }
+            catch (AuthenticationException)
+            {
+                // authentication failed and in addition it left our 
+                // ssl stream in an unusable state so cleanup needs
+                // to be done and the exception can be re-thrown for
+                // handling down the chain. (Add logging?)
+                Close();
+                FtpTrace.WriteStatus(FtpTraceLevel.Error, "FTPS Authentication Failed");
+                throw;
+            }
+        }
 #endif
 
 #if !CORE
         /// <summary>
         /// Deactivates SSL on this stream using the specified protocols and reverts back to plain-text FTP.
         /// </summary>
-        public void DeactivateEncryption() {
-			if (!IsConnected)
-				throw new InvalidOperationException("The FtpSocketStream object is not connected.");
+        public void DeactivateEncryption()
+        {
+            if (!IsConnected)
+                throw new InvalidOperationException("The FtpSocketStream object is not connected.");
 
-			if (m_sslStream == null)
-				throw new InvalidOperationException("SSL Encryption has not been enabled on this stream.");
+            if (m_sslStream == null)
+                throw new InvalidOperationException("SSL Encryption has not been enabled on this stream.");
 
-			m_sslStream.Close();
-			m_sslStream = null;
-		}
+            m_sslStream.Close();
+            m_sslStream = null;
+        }
 #endif
 
-		/// <summary>
-		/// Instructs this stream to listen for connections on the specified address and port
-		/// </summary>
-		/// <param name="address">The address to listen on</param>
-		/// <param name="port">The port to listen on</param>
-		public void Listen(IPAddress address, int port) {
-			if (!IsConnected) {
-				if (m_socket == null)
-					m_socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+        /// <summary>
+        /// Instructs this stream to listen for connections on the specified address and port
+        /// </summary>
+        /// <param name="address">The address to listen on</param>
+        /// <param name="port">The port to listen on</param>
+        public void Listen(IPAddress address, int port)
+        {
+            if (!IsConnected)
+            {
+                if (m_socket == null)
+                    m_socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-				m_socket.Bind(new IPEndPoint(address, port));
-				m_socket.Listen(1);
-			}
-		}
+                m_socket.Bind(new IPEndPoint(address, port));
+                m_socket.Listen(1);
+            }
+        }
 
-		/// <summary>
-		/// Accepts a connection from a listening socket
-		/// </summary>
-		public void Accept() {
-			if (m_socket != null)
-				m_socket = m_socket.Accept();
-		}
+        /// <summary>
+        /// Accepts a connection from a listening socket
+        /// </summary>
+        public void Accept()
+        {
+            if (m_socket != null)
+                m_socket = m_socket.Accept();
+        }
 
 #if CORE
 		public async Task AcceptAsync() {
@@ -879,28 +990,31 @@ namespace FluentFTP {
 			}
 		}
 #else
-		/// <summary>
-		/// Asynchronously accepts a connection from a listening socket
-		/// </summary>
-		/// <param name="callback"></param>
-		/// <param name="state"></param>
-		/// <returns></returns>
-		public IAsyncResult BeginAccept(AsyncCallback callback, object state) {
-			if (m_socket != null)
-				return m_socket.BeginAccept(callback, state);
-			return null;
-		}
+        /// <summary>
+        /// Asynchronously accepts a connection from a listening socket
+        /// </summary>
+        /// <param name="callback"></param>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        public IAsyncResult BeginAccept(AsyncCallback callback, object state)
+        {
+            if (m_socket != null)
+                return m_socket.BeginAccept(callback, state);
+            return null;
+        }
 
-		/// <summary>
-		/// Completes a BeginAccept() operation
-		/// </summary>
-		/// <param name="ar">IAsyncResult returned from BeginAccept</param>
-		public void EndAccept(IAsyncResult ar) {
-			if (m_socket != null) {
-				m_socket = m_socket.EndAccept(ar);
-				m_netStream = new NetworkStream(m_socket);
-			}
-		}
+        /// <summary>
+        /// Completes a BeginAccept() operation
+        /// </summary>
+        /// <param name="ar">IAsyncResult returned from BeginAccept</param>
+        public void EndAccept(IAsyncResult ar)
+        {
+            if (m_socket != null)
+            {
+                m_socket = m_socket.EndAccept(ar);
+                m_netStream = new NetworkStream(m_socket);
+            }
+        }
 #endif
-	}
+    }
 }


### PR DESCRIPTION
GetListing is based on FtpSocketStream.ReadLine to read the list of files returned by the ftp server.
ReadLine method is used across the library to read **only** the bytes required till the end of the line, so it is basically a FtpSocketStream.read of 1 char at a time.
Reading GetListing result char by char is a huge performance issue (considering also the AsyncWaitHandle.WaitOne method used for each Read).

I've added a method to FtpSocketStream class, ReadAllLines, which is able to read n characters in a single call (at the moment 100) and return the list of all lines retrieved by the server.

I've tested it with a big FTP folder (4846 files) with following results:
 - current implementation: 3.6-3.8 seconds to get the full list
 - modified implementation: 0.48-0.55 seconds

so, ~600% faster

Question: are there any unit tests?