### PR TITLE
Dispose of FtpDataStream Now Reads Control Reply

### DIFF
--- a/FluentFTP/Stream/FtpDataStream.cs
+++ b/FluentFTP/Stream/FtpDataStream.cs
@@ -139,28 +139,55 @@ namespace FluentFTP {
 			m_position = pos;
 		}
 
+		private FtpReply m_closedDataStreamReply;
+
 		/// <summary>
 		/// Disconnects (if necessary) and releases associated resources
 		/// </summary>
 		/// <param name="disposing">Disposing</param>
-		protected override void Dispose(bool disposing) {
-			if (disposing) {
-				if (IsConnected)
-					Close();
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				// If we were connected then we need to handle the response 
+				// from the control connection after closing the data
+				// connection
+				var wasConnected = IsConnected;
+
+				// Calling base dispose first to actually terminate the
+				// network streams before we handle the reply from the control
+				// connection
+				base.Dispose(true);
+
+				if (wasConnected)
+				{
+					m_closedDataStreamReply = HandleClosedDataStreamReply();
+				}
 
 				m_control = null;
 			}
-
-			base.Dispose(disposing);
+			else
+			{
+				base.Dispose(false);
+			}
 		}
 
-		/// <summary>
-		/// Closes the connection and reads the server's reply
-		/// </summary>
-		public new FtpReply Close() {
+		/// <summary> 
+		/// Closes the connection and reads the server's reply 
+		/// </summary> 
+		public new FtpReply Close()
+		{
+			// This will eventually invoke our Dispose(bool) method
+			// and assign m_closedDataStreamReply
 			base.Close();
 
-			try {
+			return m_closedDataStreamReply;
+		}
+
+		private FtpReply HandleClosedDataStreamReply()
+		{
+			try
+			{
 				if (ControlConnection != null)
 					return ControlConnection.CloseDataStream(this);
 			} finally {

--- a/FluentFTP/Stream/FtpSocketStream.cs
+++ b/FluentFTP/Stream/FtpSocketStream.cs
@@ -656,7 +656,7 @@ namespace FluentFTP
         public new void Dispose()
         {
             FtpTrace.WriteStatus(FtpTraceLevel.Verbose, "Disposing FtpSocketStream...");
-            Close();
+            base.Dispose();
         }
 
         /// <summary>
@@ -664,10 +664,28 @@ namespace FluentFTP
         /// </summary>
 #if CORE
 		public void Close() {
+            // We only implement Close for .NET Core so the API surface does not change
+            // The full .NET framework already has Close defined on Stream
+            Dispose();
+        }
 #else
         public override void Close()
         {
+            base.Close();
+        }
 #endif
+
+        /// <summary>
+        /// Disposes the stream
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                base.Dispose(false);
+                return;
+            }
+
             if (m_socket != null)
             {
                 try
@@ -733,9 +751,7 @@ namespace FluentFTP
             }
 #endif
 
-#if CORE
-            base.Dispose();
-#endif
+            base.Dispose(true);
         }
 
         /// <summary>


### PR DESCRIPTION
This resolves issue #167.

The change here was to move all of the clean-up functionality to the `Dispose(bool)` overrides and simply use the `Close()` methods to call `Dispose()`.

As `FtpDataStream.Dispose(bool)` handles the reply from the control connection, we store this in a field so it may be returned from the shadowing `FtpDataStream.Close()` method.