### PR TITLE
Removed the fixes from high-level functions which read the final reply

### DIFF
--- a/FluentFTP/Client/FtpClient_HighLevel.cs
+++ b/FluentFTP/Client/FtpClient_HighLevel.cs
@@ -1137,13 +1137,7 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				upStream.Dispose();
-
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
-				if (!EnableThreadSafeDataConnections) {
-					FtpReply status = GetReply();
-				}
-
+                
 				return true;
 
 			} catch (Exception ex1) {
@@ -1286,13 +1280,7 @@ namespace FluentFTP {
 
 				// disconnect FTP stream before exiting
 				upStream.Dispose();
-
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
-				if (!m_threadSafeDataChannels) {
-					FtpReply status = GetReply();
-				}
-
+                
 				return true;
 			} catch (Exception ex1) {
 				// close stream before throwing error
@@ -1789,12 +1777,7 @@ namespace FluentFTP {
 				// disconnect FTP stream before exiting
 				outStream.Flush();
 				downStream.Dispose();
-
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
-				if (!m_threadSafeDataChannels) {
-					FtpReply status = GetReply();
-				}
+                
 				return true;
 
 
@@ -1921,12 +1904,7 @@ namespace FluentFTP {
 				// disconnect FTP stream before exiting
 				await outStream.FlushAsync(token);
 				downStream.Dispose();
-
-				// FIX : if this is not added, there appears to be "stale data" on the socket
-				// listen for a success/failure reply
-				if (!m_threadSafeDataChannels) {
-					FtpReply status = GetReply();
-				}
+                
 				return true;
 
 			} catch (Exception ex1) {


### PR DESCRIPTION
An additional fix for issue #167.

This is no longer necessary now that FtpDataStream correctly handles the final reply itself.