### PR TITLE
Fix XML summaries

### DIFF
--- a/FluentFTP/Client/AsyncClient/DeleteDirectory.cs
+++ b/FluentFTP/Client/AsyncClient/DeleteDirectory.cs
@@ -44,8 +44,8 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Asynchronously removes a directory. Used by <see cref="DeleteDirectoryAsync(string)"/> and
-		/// <see cref="DeleteDirectoryAsync(string, FtpListOption)"/>.
+		/// Asynchronously removes a directory. Used by <see cref="DeleteDirectory(string, CancellationToken)"/> and
+		/// <see cref="DeleteDirectory(string, FtpListOption, CancellationToken)"/>.
 		/// </summary>
 		/// <param name="path">The full or relative path of the directory to delete</param>
 		/// <param name="deleteContents">Delete the contents before deleting the folder</param>

--- a/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
+++ b/FluentFTP/Client/AsyncClient/GetObjectInfo.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using FluentFTP.Client.Modules;
+using FluentFTP.Client.BaseClient;
 
 namespace FluentFTP {
 	public partial class AsyncFtpClient {
@@ -16,7 +17,7 @@ namespace FluentFTP {
 		/// Return information about a remote file system object asynchronously. 
 		/// </summary>
 		/// <remarks>
-		/// You should check the <see cref="Capabilities"/> property for the <see cref="FtpCapability.MLSD"/> 
+		/// You should check the <see cref="BaseFtpClient.Capabilities"/> property for the <see cref="FtpCapability.MLSD"/>
 		/// flag before calling this method. Failing to do so will result in an InvalidOperationException
 		/// being thrown when the server does not support machine listings. Returns null if the server response can't
 		/// be parsed or the server returns a failure completion code. The error for a failure

--- a/FluentFTP/Client/AsyncClient/Handshake.cs
+++ b/FluentFTP/Client/AsyncClient/Handshake.cs
@@ -7,7 +7,7 @@ namespace FluentFTP {
 	public partial class AsyncFtpClient {
 
 		/// <summary>
-		/// Called during <see cref="ConnectAsync()"/>. Typically extended by FTP proxies.
+		/// Called during <see cref="Connect(CancellationToken)"/>. Typically extended by FTP proxies.
 		/// </summary>
 		protected virtual async Task HandshakeAsync(CancellationToken token = default(CancellationToken)) {
 			FtpReply reply;

--- a/FluentFTP/Client/AsyncClient/Noop.cs
+++ b/FluentFTP/Client/AsyncClient/Noop.cs
@@ -12,7 +12,7 @@ namespace FluentFTP {
 	public partial class AsyncFtpClient {
 
 		/// <summary>
-		/// Sends the NOOP command according to <see cref="NoopInterval"/> (effectively a no-op if 0).
+		/// Sends the NOOP command according to <see cref="FtpConfig.NoopInterval"/> (effectively a no-op if 0).
 		/// Please call <see cref="GetReply"/> as needed to read the "OK" command sent by the server and prevent stale data on the socket.
 		/// Note that response is not guaranteed by all FTP servers when sent during file transfers.
 		/// </summary>

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -10,6 +10,7 @@ using FluentFTP.Servers;
 using FluentFTP.Helpers;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace FluentFTP.Client.BaseClient {
 	public partial class BaseFtpClient {
@@ -82,8 +83,8 @@ namespace FluentFTP.Client.BaseClient {
 		}
 
 		/// <summary>
-		/// When last command was sent (NOOP or other), for having <see cref="Noop"/>
-		/// Respects the <see cref="NoopInterval"/>.
+		/// When last command was sent (NOOP or other), for having <see cref="FtpClient.Noop"/>/<see cref="AsyncFtpClient.NoopAsync(CancellationToken)"/>.
+		/// Respects the <see cref="FtpConfig.NoopInterval"/>.
 		/// </summary>
 		protected DateTime LastCommandTimestamp;
 

--- a/FluentFTP/Client/SyncClient/Noop.cs
+++ b/FluentFTP/Client/SyncClient/Noop.cs
@@ -12,7 +12,7 @@ namespace FluentFTP {
 	public partial class FtpClient {
 
 		/// <summary>
-		/// Sends the NOOP command according to <see cref="NoopInterval"/> (effectively a no-op if 0).
+		/// Sends the NOOP command according to <see cref="FtpConfig.NoopInterval"/> (effectively a no-op if 0).
 		/// Please call <see cref="GetReply"/> as needed to read the "OK" command sent by the server and prevent stale data on the socket.
 		/// Note that response is not guaranteed by all FTP servers when sent during file transfers.
 		/// </summary>

--- a/FluentFTP/Enums/FtpVerify.cs
+++ b/FluentFTP/Enums/FtpVerify.cs
@@ -16,7 +16,7 @@ namespace FluentFTP {
 		/// <summary>
 		/// The checksum of the file is verified, if supported by the server.
 		/// If the checksum comparison fails then we retry the download/upload
-		/// a specified amount of times before giving up. (See <see cref="BaseFtpClient.RetryAttempts"/>)
+		/// a specified amount of times before giving up. (See <see cref="FtpConfig.RetryAttempts"/>)
 		/// </summary>
 		Retry = 1,
 

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -12,14 +12,14 @@ using System.Threading.Tasks;
 
 namespace FluentFTP {
 
-#if NETFRAMEWORK
-	[Serializable]
-#endif
 	/// <summary>
 	/// Holds all the configuration settings for a single FTP client.
 	/// One FtpConfig object can only be bound to one client at a time.
 	/// If you want to reuse it across multiple FTP clients, then clone it and then reuse it.
 	/// </summary>
+#if NETFRAMEWORK
+	[Serializable]
+#endif
 	public class FtpConfig {
 
 		private BaseFtpClient _client = null;
@@ -39,17 +39,17 @@ namespace FluentFTP {
 		/// <summary>
 		/// Should the FTP server host IP/domain be shown in the logs (true) or masked out (false)?
 		/// </summary>
-		public bool LogHost { get; set; } =false;
+		public bool LogHost { get; set; } = false;
 
 		/// <summary>
 		/// Should the FTP username be shown in the logs (true) or masked out (false)?
 		/// </summary>
-		public bool LogUserName { get; set; } =false;
+		public bool LogUserName { get; set; } = false;
 
 		/// <summary>
 		/// Should the FTP password be shown in the logs (true) or masked out (false)?
 		/// </summary>
-		public bool LogPassword { get; set; } =false;
+		public bool LogPassword { get; set; } = false;
 
 		/// <summary>
 		/// Flags specifying which versions of the internet protocol (IPV4 or IPV6) to
@@ -60,7 +60,7 @@ namespace FluentFTP {
 		/// to FtpIpVersion.IPv4 will cause the connection process to
 		/// ignore IPv6 addresses. The default value is ANY version.
 		/// </summary>
-		public FtpIpVersion InternetProtocolVersions { get; set; } =FtpIpVersion.ANY;
+		public FtpIpVersion InternetProtocolVersions { get; set; } = FtpIpVersion.ANY;
 
 		protected int _socketPollInterval = 15000;
 
@@ -108,10 +108,10 @@ namespace FluentFTP {
 
 		/// <summary>
 		/// Gets or sets the length of time in milliseconds after last command
-		/// (NOOP or other) that a NOOP command is sent by <see cref="Noop"/>.
+		/// (NOOP or other) that a NOOP command is sent by <see cref="FtpClient.Noop"/>/<see cref="AsyncFtpClient.NoopAsync(System.Threading.CancellationToken)"/>.
 		/// This is called during downloading/uploading if
 		/// <see cref="EnableThreadSafeDataConnections"/> is false. Setting this
-		/// interval to 0 disables <see cref="Noop"/> all together.
+		/// interval to 0 disables <see cref="FtpClient.Noop"/>/<see cref="AsyncFtpClient.NoopAsync(System.Threading.CancellationToken)"/> all together.
 		/// The default value is 0 (disabled).
 		/// </summary>
 		public int NoopInterval { get; set; } = 0;
@@ -121,7 +121,7 @@ namespace FluentFTP {
 		/// will set which features are available by executing the FEAT command
 		/// when the connect method is called.
 		/// </summary>
-		public bool CheckCapabilities { get; set; } =true;
+		public bool CheckCapabilities { get; set; } = true;
 
 		/// <summary>
 		/// Client certificates to be used in SSL authentication process
@@ -161,14 +161,14 @@ namespace FluentFTP {
 		/// by defining a specific type of passive or active data
 		/// connection here.
 		/// </summary>
-		public FtpDataConnectionType DataConnectionType { get; set; } =FtpDataConnectionType.AutoPassive;
+		public FtpDataConnectionType DataConnectionType { get; set; } = FtpDataConnectionType.AutoPassive;
 
 		/// <summary>
 		/// Disconnect from the server without sending QUIT. This helps
 		/// work around IOExceptions caused by buggy connection resets
 		/// when closing the control connection.
 		/// </summary>
-		public bool DisconnectWithQuit { get; set; } =true;
+		public bool DisconnectWithQuit { get; set; } = true;
 
 		/// <summary>
 		/// Before we disconnect from the server, send the Shutdown signal on the socket stream.
@@ -179,7 +179,7 @@ namespace FluentFTP {
 		/// Gets or sets the length of time in milliseconds to wait for a connection 
 		/// attempt to succeed before giving up. Default is 15000 (15 seconds).
 		/// </summary>
-		public int ConnectTimeout { get; set; }= 15000;
+		public int ConnectTimeout { get; set; } = 15000;
 
 		/// <summary>
 		/// Gets or sets the length of time wait in milliseconds for data to be
@@ -454,7 +454,7 @@ namespace FluentFTP {
 		/// Controls if the high-level API uploads files in Binary or ASCII mode.
 		/// </summary>
 		public FtpDataType UploadDataType { get; set; } = FtpDataType.Binary;
-		
+
 		/// <summary>
 		/// Controls if the high-level API downloads files in Binary or ASCII mode.
 		/// </summary>

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4Proxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4Proxy.cs
@@ -18,7 +18,7 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		}
 
 		/// <summary>
-		/// Called during <see cref="ConnectAsync()"/>. Typically extended by FTP proxies.
+		/// Called during <see cref="ConnectAsync(FtpSocketStream, CancellationToken)"/>. Typically extended by FTP proxies.
 		/// </summary>
 		protected override async Task HandshakeAsync(CancellationToken token = default) {
 			await ((IInternalFtpClient)this).GetBaseStream().ReadAsync(new byte[6], 0, 6, token);

--- a/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4aProxy.cs
+++ b/FluentFTP/Proxy/AsyncProxy/AsyncFtpClientSocks4aProxy.cs
@@ -18,7 +18,7 @@ namespace FluentFTP.Proxy.AsyncProxy {
 		}
 
 		/// <summary>
-		/// Called during <see cref="ConnectAsync()"/>. Typically extended by FTP proxies.
+		/// Called during <see cref="ConnectAsync(FtpSocketStream, CancellationToken)"/>. Typically extended by FTP proxies.
 		/// </summary>
 		protected override async Task HandshakeAsync(CancellationToken token = default) {
 			await ((IInternalFtpClient)this).GetBaseStream().ReadAsync(new byte[6], 0, 6, token);


### PR DESCRIPTION
Found some XML summaries that hadn't been updated with the changes in v40.

I was not sure what to do with these two:
* `FtpListItem.LinkObject` is unreferenced and its summary references the removed `FtpListOption.DerefLinks`
* `FtpConfig.NoopInterval` summary references the removed `EnableThreadSafeDataConnections`