### PR TITLE
Added SwitchToClearText.

### DIFF
--- a/FluentFTP/Client/AsyncClient/SwitchToClearText.cs
+++ b/FluentFTP/Client/AsyncClient/SwitchToClearText.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+
+namespace FluentFTP {
+	public partial class AsyncFtpClient {
+
+		/// <summary>
+		/// Send a 'CCC' comamnd to the FTP server and if successful closes the undelying ssl stream.
+		/// </summary>
+		public async Task SwitchToClearText() {
+
+			var reply = await Execute("CCC");
+			if (reply.Success) {
+				m_stream.SwitchToUnsecuredMode();
+				Config.EncryptionMode = FtpEncryptionMode.None;
+			}
+		}
+
+	}
+}

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1866,6 +1866,15 @@ namespace FluentFTP {
 			};
 		}
 
+		/// <summary>
+		/// Closes the undelying ssl stream.
+		/// </summary>
+		internal void SwitchToUnsecuredMode() {
+			if (m_sslStream != null) {
+				DisposeSslStream();
+				m_sslStream = null;
+			}
+		}
 	}
 
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously


### PR DESCRIPTION
Added switch to clear text method in async client.
The methods sends a CCC command and switches FTPScoketStream to unsecure mode.