### PR TITLE
FluentFTP.Logging: fix dependency to Microsoft.Extensions.Logging

### DIFF
--- a/FluentFTP.Logging/FluentFTP.Logging.csproj
+++ b/FluentFTP.Logging/FluentFTP.Logging.csproj
@@ -39,7 +39,7 @@
         <!-- Reference the first version of FluentFTP that exposes IFluentLogger. Do not change this version. -->
         <PackageReference Include="FluentFTP" Version="43.0.1" />
         <!-- Reference the oldest version of MELA possible. Do not change this version. -->
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
there is no reason to reference the implementation package.