### PR TITLE
Resolves #1768

### DIFF
--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -530,15 +530,15 @@ namespace FluentFTP.Client.BaseClient {
 			reply.Command = string.IsNullOrEmpty(command) ? string.Empty : LogMaskModule.MaskCommand(this, command);
 
 			if (LastReplies == null) {
-				LastReplies = new List<FtpReply> {
+				LastReplies = new List<FtpReply>(5) {
 					reply
 				};
 			}
 			else {
-				LastReplies.Insert(0, reply);
-				if (LastReplies.Count > 5) {
-					LastReplies.RemoveAt(5);
+				if (LastReplies.Count > 0 && LastReplies.Count == LastReplies.Capacity) {
+					LastReplies.RemoveAt(LastReplies.Count - 1);
 				}
+				LastReplies.Insert(0, reply);
 			}
 
 			return reply;


### PR DESCRIPTION
Allow configurable maximum number of server replies in FtpClient.LastReplies.

Allows users to configure capacity for LastReplies by assigning it.
For example:
`ftpClient.LastReplies = new List<FtpReply>(50);`

Default capacity is 5, as previously hardcoded.