### PR TITLE
Add SSL client authentication options configuration for legacy RSA FTPS servers

### DIFF
--- a/FluentFTP.CSharpExamples/ConnectFTPSLegacyRSA.cs
+++ b/FluentFTP.CSharpExamples/ConnectFTPSLegacyRSA.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentFTP;
+
+namespace Examples {
+	internal static class ConnectFtpsLegacyRsaExample {
+
+		/// <summary>
+		/// Example: Connect to a legacy FTPS server that only supports RSA key-exchange ciphers.
+		///
+		/// Some legacy FTPS servers (especially on Linux) only negotiate RSA key-exchange TLS ciphers
+		/// (e.g., TLS_RSA_WITH_AES_256_GCM_SHA384) and fail when .NET on Linux offers only ECDHE ciphers.
+		///
+		/// This example shows how to configure FluentFTP to work with such servers by customizing
+		/// the SSL client authentication options to include RSA cipher suites.
+		///
+		/// Security Note: Enabling RSA key-exchange ciphers reduces security (no forward secrecy).
+		/// Only use this for interop with legacy FTPS servers that cannot be upgraded.
+		/// </summary>
+		public static void ConnectFtpsLegacyRsa() {
+			using (var conn = new FtpClient("localhost", "username", "password")) {
+				// Set encryption mode to Explicit FTPS (AUTH TLS)
+				conn.Config.EncryptionMode = FtpEncryptionMode.Explicit;
+
+				// Configure SSL client authentication options to include RSA cipher suites
+				// This is required for legacy servers that only support RSA key-exchange
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+				conn.ConfigureSslClientAuthenticationOptions += (client, e) => {
+#if NET5_0_OR_GREATER
+					// Set cipher suites policy to include RSA key-exchange ciphers
+					// CipherSuitesPolicy is only available in .NET 5.0+
+					e.Options.CipherSuitesPolicy = new CipherSuitesPolicy(new[] {
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+					});
+#endif
+				};
+#endif
+				// Optionally: Skip certificate validation for testing (not recommended for production)
+				// conn.Config.ValidateAnyCertificate = true;
+				try {
+					// Connect to the server
+					conn.Connect();
+				}
+				catch (Exception e) {
+					Console.WriteLine(e);
+					throw;
+				}
+
+
+				// Now you can use the FTP client normally
+				Console.WriteLine("Connected successfully!");
+				Console.WriteLine($"Current directory: {conn.GetWorkingDirectory()}");
+			}
+		}
+
+		/// <summary>
+		/// Example: Connect to a legacy FTPS server that only supports RSA key-exchange ciphers (Async version).
+		/// </summary>
+		public static async Task ConnectFtpsLegacyRsaAsync() {
+			var token = new CancellationToken();
+			using (var conn = new AsyncFtpClient("localhost", "username", "password")) {
+
+				// Set encryption mode to Explicit FTPS (AUTH TLS)
+				conn.Config.EncryptionMode = FtpEncryptionMode.Explicit;
+
+				// Configure SSL client authentication options to include RSA cipher suites
+				// This is required for legacy servers that only support RSA key-exchange
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+				conn.ConfigureSslClientAuthenticationOptions += (client, e) => {
+#if NET5_0_OR_GREATER
+					// Set cipher suites policy to include RSA key-exchange ciphers
+					// CipherSuitesPolicy is only available in .NET 5.0+
+					e.Options.CipherSuitesPolicy = new CipherSuitesPolicy(new[] {
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+					});
+#endif
+				};
+#endif
+
+				// Optionally: Skip certificate validation for testing (not recommended for production)
+				// conn.Config.ValidateAnyCertificate = true;
+
+				// Connect to the server
+				await conn.Connect(token);
+
+				// Now you can use the FTP client normally
+				Console.WriteLine("Connected successfully!");
+				Console.WriteLine($"Current directory: {await conn.GetWorkingDirectory(token)}");
+			}
+		}
+
+		/// <summary>
+		/// Example: Minimal configuration for legacy RSA-only servers.
+		/// This is a simplified version that only includes the most common RSA cipher suites.
+		/// </summary>
+		public static void ConnectFtpsLegacyRsaMinimal() {
+			using (var conn = new FtpClient("localhost", "username", "password")) {
+				conn.Config.EncryptionMode = FtpEncryptionMode.Explicit;
+
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+				conn.ConfigureSslClientAuthenticationOptions += (client, e) => {
+#if NET5_0_OR_GREATER
+					// Minimal set: Only the most common RSA cipher suites
+					e.Options.CipherSuitesPolicy = new CipherSuitesPolicy(new[] {
+						TlsCipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+						TlsCipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					});
+#endif
+				};
+#endif
+				// Optionally: Skip certificate validation for testing (not recommended for production)
+				// conn.Config.ValidateAnyCertificate = true;
+				conn.Connect();
+			}
+		}
+
+	}
+
+}

--- a/FluentFTP/Client/BaseClient/ConfigureSslClientAuthenticationOptions.cs
+++ b/FluentFTP/Client/BaseClient/ConfigureSslClientAuthenticationOptions.cs
@@ -1,0 +1,24 @@
+using System.Net.Security;
+using FluentFTP;
+
+namespace FluentFTP.Client.BaseClient {
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+	public partial class BaseFtpClient {
+
+		/// <summary>
+		/// Fires the SSL client authentication options configuration event
+		/// </summary>
+		/// <param name="options">The SSL client authentication options to be customized</param>
+		internal void OnConfigureSslClientAuthenticationOptions(SslClientAuthenticationOptions options) {
+			var evt = m_ConfigureSslClientAuthenticationOptions;
+
+			if (evt != null) {
+				var e = new FtpSslClientAuthenticationOptionsEventArgs(options);
+				evt(this, e);
+			}
+		}
+
+	}
+#endif
+}
+

--- a/FluentFTP/Client/BaseClient/Properties.cs
+++ b/FluentFTP/Client/BaseClient/Properties.cs
@@ -383,6 +383,39 @@ namespace FluentFTP.Client.BaseClient {
 			remove => m_ValidateCertificate -= value;
 		}
 
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+		protected FtpSslClientAuthenticationOptions m_ConfigureSslClientAuthenticationOptions = null;
+
+		/// <summary>
+		/// Event is fired when SSL client authentication options need to be configured before the TLS handshake.
+		/// This allows customization of SSL options such as CipherSuitesPolicy for legacy FTPS servers
+		/// that only support RSA key-exchange ciphers (e.g., on Linux where .NET's default cipher list may not include RSA suites).
+		/// <para>
+		/// Example usage for legacy RSA-only servers:
+		/// <code>
+		/// ftp.ConfigureSslClientAuthenticationOptions += (client, e) =>
+		/// {
+		/// #if NET5_0_OR_GREATER
+		///     e.Options.CipherSuitesPolicy = new CipherSuitesPolicy(new[]
+		///     {
+		///         TlsCipherSuite.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		///         TlsCipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		///     });
+		/// #endif
+		/// };
+		/// </code>
+		/// </para>
+		/// <para>
+		/// <b>Security Note:</b> Enabling RSA key-exchange ciphers reduces security (no forward secrecy).
+		/// Only use this for interop with legacy FTPS servers that cannot be upgraded.
+		/// </para>
+		/// </summary>
+		public event FtpSslClientAuthenticationOptions ConfigureSslClientAuthenticationOptions {
+			add => m_ConfigureSslClientAuthenticationOptions += value;
+			remove => m_ConfigureSslClientAuthenticationOptions -= value;
+		}
+#endif
+
 		protected string m_systemType = "UNKNOWN";
 
 		/// <summary>

--- a/FluentFTP/Client/FakeClient/FakeAsyncFtpClient.cs
+++ b/FluentFTP/Client/FakeClient/FakeAsyncFtpClient.cs
@@ -29,6 +29,9 @@ public class FakeAsyncFtpClient : IAsyncFtpClient {
 	public List<FtpCapability> Capabilities { get; }
 	public FtpHashAlgorithm HashAlgorithms { get; }
 	public event FtpSslValidation ValidateCertificate;
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+	public event FtpSslClientAuthenticationOptions ConfigureSslClientAuthenticationOptions;
+#endif
 	public string SystemType { get; }
 	public FtpServer ServerType { get; }
 	public FtpBaseServer ServerHandler { get; set; }

--- a/FluentFTP/Client/FakeClient/FakeFtpClient.cs
+++ b/FluentFTP/Client/FakeClient/FakeFtpClient.cs
@@ -29,6 +29,9 @@ public class FakeFtpClient : IFtpClient {
 	public List<FtpCapability> Capabilities { get; }
 	public FtpHashAlgorithm HashAlgorithms { get; }
 	public event FtpSslValidation ValidateCertificate;
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+	public event FtpSslClientAuthenticationOptions ConfigureSslClientAuthenticationOptions;
+#endif
 	public string SystemType { get; }
 	public FtpServer ServerType { get; }
 	public FtpBaseServer ServerHandler { get; set; }

--- a/FluentFTP/Client/Interfaces/IBaseFtpClient.cs
+++ b/FluentFTP/Client/Interfaces/IBaseFtpClient.cs
@@ -31,6 +31,9 @@ namespace FluentFTP {
 		List<FtpCapability> Capabilities { get; }
 		FtpHashAlgorithm HashAlgorithms { get; }
 		event FtpSslValidation ValidateCertificate;
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+		event FtpSslClientAuthenticationOptions ConfigureSslClientAuthenticationOptions;
+#endif
 		string SystemType { get; }
 		FtpServer ServerType { get; }
 		FtpBaseServer ServerHandler { get; set; }

--- a/FluentFTP/Events/FtpSslClientAuthenticationOptions.cs
+++ b/FluentFTP/Events/FtpSslClientAuthenticationOptions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Security;
+using FluentFTP.Client.BaseClient;
+
+namespace FluentFTP {
+#if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+	/// <summary>
+	/// Event is fired when SSL client authentication options need to be configured before the TLS handshake.
+	/// This allows customization of SSL options such as CipherSuitesPolicy for legacy FTPS servers.
+	/// </summary>
+	/// <param name="control">The control connection that triggered the event</param>
+	/// <param name="e">Event args containing the SslClientAuthenticationOptions to customize</param>
+	public delegate void FtpSslClientAuthenticationOptions(BaseFtpClient control, FtpSslClientAuthenticationOptionsEventArgs e);
+
+	/// <summary>
+	/// Event args for the FtpSslClientAuthenticationOptions delegate
+	/// </summary>
+	public class FtpSslClientAuthenticationOptionsEventArgs : EventArgs {
+		private SslClientAuthenticationOptions m_options = null;
+
+		/// <summary>
+		/// The SSL client authentication options to be customized.
+		/// Modify this object to configure SSL settings such as CipherSuitesPolicy.
+		/// </summary>
+		public SslClientAuthenticationOptions Options {
+			get => m_options;
+			set => m_options = value ?? throw new ArgumentNullException(nameof(value));
+		}
+
+		/// <summary>
+		/// Creates a new instance of FtpSslClientAuthenticationOptionsEventArgs
+		/// </summary>
+		/// <param name="options">The SSL client authentication options</param>
+		public FtpSslClientAuthenticationOptionsEventArgs(SslClientAuthenticationOptions options) {
+			m_options = options ?? throw new ArgumentNullException(nameof(options));
+		}
+	}
+#endif
+}

--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -192,7 +192,7 @@ namespace FluentFTP {
 		public bool DisconnectWithQuit { get; set; } = true;
 
 		/// <summary>
-		/// Gets or sets the length of time in milliseconds to wait for a connection 
+		/// Gets or sets the length of time in milliseconds to wait for a connection
 		/// attempt to succeed before giving up. Default is 0 (Use OS default timeout)
 		/// See: https://github.com/robinrodricks/FluentFTP/wiki/FTP-Connection#connection-timeout-settings
 		/// and: https://github.com/robinrodricks/FluentFTP/wiki/FTP-Connection#faq_timeoutwindows
@@ -218,7 +218,7 @@ namespace FluentFTP {
 
 		/// <summary>
 		/// Gets or sets the length of time in milliseconds the data channel
-		/// should wait for the server to send data. Default value is 
+		/// should wait for the server to send data. Default value is
 		/// 15000 (15 seconds).
 		/// </summary>
 		public int DataConnectionReadTimeout { get; set; } = 15000;
@@ -226,7 +226,7 @@ namespace FluentFTP {
 		protected bool _keepAlive = false;
 
 		/// <summary>
-		/// Gets or sets a value indicating if <see cref="System.Net.Sockets.SocketOptionName.KeepAlive"/> should be set on 
+		/// Gets or sets a value indicating if <see cref="System.Net.Sockets.SocketOptionName.KeepAlive"/> should be set on
 		/// the underlying stream's socket. If the connection is alive, the option is
 		/// adjusted in real-time. The value is stored and the KeepAlive option is set
 		/// accordingly upon any new connections. The value set here is also applied to
@@ -305,7 +305,7 @@ namespace FluentFTP {
 		protected FtpParser _parser = FtpParser.Auto;
 
 		/// <summary>
-		/// File listing parser to be used. 
+		/// File listing parser to be used.
 		/// Automatically calculated based on the type of the server at the time of connection.
 		/// If you want to override this property, make sure to do it after calling Connect.
 		/// </summary>
@@ -468,7 +468,7 @@ namespace FluentFTP {
 		}
 
 		/// <summary>
-		/// Defines which verification types should be performed when 
+		/// Defines which verification types should be performed when
 		/// uploading/downloading files using the high-level APIs.
 		/// Multiple verification types can be combined.
 		/// </summary>


### PR DESCRIPTION
This PR adds a configuration hook that allows users to customize `SslClientAuthenticationOptions` before the TLS handshake, enabling support for Linux for legacy FTPS servers that only negotiate RSA key-exchange ciphers.

The problem: 

On Linux, .NET’s SslStream does not offer RSA key-exchange cipher suites by default. As a result, FluentFTP cannot complete the TLS handshake on these servers unless it exposes SslClientAuthenticationOptions and allows custom CipherSuitesPolicy.

Microsoft documents this behavior [here](https://learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/default-cipher-suites-for-tls-on-linux).

The commits added: 

- Added `ConfigureSslClientAuthenticationOptions` property to `FtpConfig` that allows users to customize `SslClientAuthenticationOptions` before authentication
- Updated TLS handshake code to use `SslClientAuthenticationOptions` pattern in both synchronous and async methods
- Added example file demonstrating how to configure FluentFTP for legacy RSA-only servers

I've created a repository with instructions on how to reproduce the handshake error. The repository, including instructions on how to setup the environment, can be found [here](https://github.com/mamuleanu/FTPS-legacy).


**UPDATE:**

As per PR feedback, the PR now adds an event handler that allows users to customize `SslClientAuthenticationOptions` before the TLS handshake, enabling support for legacy FTPS servers

Changes:

- **Added `FtpSslClientAuthenticationOptions` event delegate and event args class** - Infrastructure for the event
- **Added `ConfigureSslClientAuthenticationOptions` event to `BaseFtpClient`** - Event handler that allows customization of SSL options
- **Added `OnConfigureSslClientAuthenticationOptions` helper method** - Internal method to fire the event (following the same pattern as `ValidateCertificate`)
- **Added example file** - `ConnectFTPSLegacyRSA.cs` demonstrating how to configure FluentFTP for legacy RSA-only servers
