### PR TITLE
Enable CustomStream CCC Support

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -154,7 +154,7 @@ namespace FluentFTP {
 			}
 
 			if (m_stream.IsEncrypted && Config.EncryptAuthenticationOnly) {
-				if (HasFeature(FtpCapability.CCC) && !m_stream.IsCustomStream) {
+				if (HasFeature(FtpCapability.CCC)) {
 					reply = await Execute("CCC", token);
 					if (reply.Success) {
 						await m_stream.DeActivateEncryptionAsync(token);

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -151,7 +151,7 @@ namespace FluentFTP {
 			}
 
 			if (m_stream.IsEncrypted && Config.EncryptAuthenticationOnly) {
-				if (HasFeature(FtpCapability.CCC) && !m_stream.IsCustomStream) {
+				if (HasFeature(FtpCapability.CCC)) {
 					reply = Execute("CCC");
 					if (reply.Success) {
 						m_stream.DeActivateEncryption();

--- a/FluentFTP/Streams/FtpSocketStream.cs
+++ b/FluentFTP/Streams/FtpSocketStream.cs
@@ -1588,8 +1588,9 @@ namespace FluentFTP {
 				m_sslStream = null;
 			}
 			else if (m_customStream != null) {
-				throw new NotImplementedException("SSL Encryption deactivation not supported on this stream.");
-			}	
+				DisposeCustomStream();
+				m_customStream = null;
+			}
 			else {
 				throw new InvalidOperationException("SSL Encryption has not been enabled on this stream.");
 			}
@@ -1612,7 +1613,8 @@ namespace FluentFTP {
 				m_sslStream = null;
 			}
 			else if (m_customStream != null) {
-				throw new NotImplementedException("SSL Encryption deactivation not supported on this stream.");
+				await DisposeCustomStreamAsync();
+				m_customStream = null;
 			}
 			else {
 				throw new InvalidOperationException("SSL Encryption has not been enabled on this stream.");


### PR DESCRIPTION
Note: Needs an up-to-date CustomStream, such as FluentFTP.GnuTLS