### PR TITLE
FtpConfig.CopyTo: add copying of missing properties

### DIFF
--- a/FluentFTP/Model/FtpConfig.cs
+++ b/FluentFTP/Model/FtpConfig.cs
@@ -711,6 +711,18 @@ namespace FluentFTP {
 			write.ClientCertificates.Clear();
 			write.ClientCertificates.AddRange(read.ClientCertificates);
 
+			write.AddressResolver = read.AddressResolver;
+			write.CheckCapabilities = read.CheckCapabilities;
+			write.EncryptAuthenticationOnly = read.EncryptAuthenticationOnly;
+			write.LogDurations = read.LogDurations;
+			if (read.PreserveTrailingSlashCmdList == null) {
+				write.PreserveTrailingSlashCmdList = null;
+			}
+			else {
+				write.PreserveTrailingSlashCmdList = new List<string>();
+				write.PreserveTrailingSlashCmdList.AddRange(read.PreserveTrailingSlashCmdList);
+			}
+
 		}
 
 		internal bool ShouldAutoNavigate(string absPath) {


### PR DESCRIPTION
FtpConfig.CopyTo was not handling these properties: AddressResolver, CheckCapabilities, EncryptAuthenticationOnly, LogDurations, PreserveTrailingSlashCmdList.  I've added them.  Now the only property that isn't copied is Client, which shouldn't be.