### PR TITLE
Exception can causesnull reference error, fix

### DIFF
--- a/FluentFTP/Client/BaseClient/NoopDaemon.cs
+++ b/FluentFTP/Client/BaseClient/NoopDaemon.cs
@@ -106,7 +106,9 @@ namespace FluentFTP.Client.BaseClient {
 					if (gotEx) {
 						((IInternalFtpClient)this).LogStatus(FtpTraceLevel.Verbose, "Indicating connection lost (NoopDaemon)");
 						Status.NoopDaemonEnable = false;
-						m_stream.ConnectionState = FtpConnectionState.PendingDisconnect;
+						if (m_stream != null) {
+							m_stream.ConnectionState = FtpConnectionState.PendingDisconnect;
+						}
 					}
 
 


### PR DESCRIPTION
Can happen with GnuTLS or SslStream when reaching SSL session length limit.