### PR TITLE
Security Fix issue #1838

### DIFF
--- a/FluentFTP/Client/AsyncClient/DownloadUriBytes.cs
+++ b/FluentFTP/Client/AsyncClient/DownloadUriBytes.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 
 namespace FluentFTP {
@@ -21,12 +22,12 @@ namespace FluentFTP {
 				throw new ArgumentException("Required parameter is null or blank.", nameof(uri));
 			}
 
-			LogFunction(nameof(DownloadUriBytes), new object[] { uri });
-
 			// Example:
 			// "ftp[s]://username:password@host:port/path"
 
 			var formalUri = new Uri(uri);
+
+			LogFunction(nameof(DownloadUriBytes), new object[] { LogMaskModule.MaskUri(this, formalUri) });
 
 			this.Host = formalUri.DnsSafeHost;
 			this.Port = formalUri.Port;

--- a/FluentFTP/Client/Modules/LogMaskModule.cs
+++ b/FluentFTP/Client/Modules/LogMaskModule.cs
@@ -75,5 +75,23 @@ namespace FluentFTP.Client.Modules {
 			return message;
 		}
 
+		public static string MaskUri(BaseFtpClient client, Uri uri) {
+			var builder = new UriBuilder(uri);
+
+			if (!client.Config.LogUserName) {
+				builder.UserName = "***";
+			}
+
+			if (!client.Config.LogPassword) {
+				builder.Password = "***";
+			}
+
+			if (!client.Config.LogHost) {
+				builder.Host = "***";
+			}
+
+			return builder.Uri.ToString();
+		}
+
 	}
 }

--- a/FluentFTP/Client/SyncClient/DownloadUriBytes.cs
+++ b/FluentFTP/Client/SyncClient/DownloadUriBytes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 
+using FluentFTP.Client.Modules;
 using FluentFTP.Helpers;
 
 namespace FluentFTP {
@@ -19,12 +20,12 @@ namespace FluentFTP {
 				throw new ArgumentException("Required parameter is null or blank.", nameof(uri));
 			}
 
-			LogFunction(nameof(DownloadUriBytes), new object[] { uri });
-
 			// Example:
 			// "ftp[s]://username:password@host:port/path"
 
 			var formalUri = new Uri(uri);
+
+			LogFunction(nameof(DownloadUriBytes), new object[] { LogMaskModule.MaskUri(this, formalUri) });
 
 			this.Host = formalUri.DnsSafeHost;
 			this.Port = formalUri.Port;


### PR DESCRIPTION
"Both DownloadUriBytes overloads (sync and async) call LogFunction with the raw URI string before parsing it for credentials. If the URI contains embedded credentials — e.g. ftp://alice:secretpass@example.com/file.txt — the plaintext password is written verbatim to every configured log sink."