### PR TITLE
Fix small bug re. ReadTimeout setting

### DIFF
--- a/FluentFTP/Client/AsyncClient/Connect.cs
+++ b/FluentFTP/Client/AsyncClient/Connect.cs
@@ -84,6 +84,7 @@ namespace FluentFTP {
 
 			m_hashAlgorithms = FtpHashAlgorithm.NONE;
 			m_stream.ConnectTimeout = Config.ConnectTimeout;
+			m_stream.ReadTimeout = Config.ReadTimeout;
 			await ConnectAsync(m_stream, token);
 
 			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);

--- a/FluentFTP/Client/BaseClient/GetReply.cs
+++ b/FluentFTP/Client/BaseClient/GetReply.cs
@@ -173,7 +173,6 @@ namespace FluentFTP.Client.BaseClient {
 
 						if (timeOut >= 0) {
 							// BLOCKING read
-							m_stream.ReadTimeout = Config.ReadTimeout;
 							response = m_stream.ReadLine(Encoding);
 						}
 						else {
@@ -413,7 +412,6 @@ namespace FluentFTP.Client.BaseClient {
 
 						if (timeOut >= 0) {
 							// BLOCKING read
-							m_stream.ReadTimeout = Config.ReadTimeout;
 							response = await m_stream.ReadLineAsync(Encoding, token);
 						}
 						else {

--- a/FluentFTP/Client/SyncClient/Connect.cs
+++ b/FluentFTP/Client/SyncClient/Connect.cs
@@ -83,6 +83,7 @@ namespace FluentFTP {
 
 			m_hashAlgorithms = FtpHashAlgorithm.NONE;
 			m_stream.ConnectTimeout = Config.ConnectTimeout;
+			m_stream.ReadTimeout = Config.ReadTimeout;
 			Connect(m_stream);
 
 			m_stream.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, Config.SocketKeepAlive);


### PR DESCRIPTION
For some reason, `m_stream.ReadTimeout` was being (repeatedly) set in `GetReply` - instead of once at connect time (from config).

If at any time the user were to want to change the timeout to some other value during his client session, this would not work.

This concerns the control connection.

The data connection(s) (active/passive) do it this way also, already.