### PR TITLE
Improve AutoConnect FEAT check

### DIFF
--- a/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/AsyncClient/OpenPassiveDataStream.cs
@@ -36,7 +36,7 @@ namespace FluentFTP {
 
 			for (int a = 0; a <= Config.PassiveMaxAttempts;) {
 
-				if (HasFeature(FtpCapability.EPSV) && type is FtpDataConnectionType.EPSV or FtpDataConnectionType.AutoPassive && !Status.EPSVNotSupported) {
+				if (!Status.EPSVNotSupported && (type is FtpDataConnectionType.EPSV || (HasFeature(FtpCapability.EPSV) && type is FtpDataConnectionType.AutoPassive))) {
 					// execute EPSV to try enhanced-passive mode
 					if (!(reply = await Execute("EPSV", token)).Success) {
 						// if we're connected with IPv4 and data channel type is AutoPassive then fallback to IPv4

--- a/FluentFTP/Client/SyncClient/OpenPassiveDataStream.cs
+++ b/FluentFTP/Client/SyncClient/OpenPassiveDataStream.cs
@@ -34,8 +34,7 @@ namespace FluentFTP {
 
 			for (int a = 0; a <= Config.PassiveMaxAttempts;) {
 
-				if (HasFeature(FtpCapability.EPSV) && type is FtpDataConnectionType.EPSV or FtpDataConnectionType.AutoPassive && !Status.EPSVNotSupported) {
-
+				if (!Status.EPSVNotSupported && (type is FtpDataConnectionType.EPSV || (HasFeature(FtpCapability.EPSV) && type is FtpDataConnectionType.AutoPassive))) {
 					// execute EPSV to try enhanced-passive mode
 					if (!(reply = Execute("EPSV")).Success) {
 


### PR DESCRIPTION
If someone **REALLY** wants to **force** EPSV regardless of FEAT responses, he needs to use EPSV instead of AutoConnect.